### PR TITLE
fix: bootstrap stop command is changed to run  <docker-compose stop> instead of <docker-compose down>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 -   Faucet `1.0.1` upgrade.
 -   Removed unused `sshpk` service and dependency.
 -   Removed unused `forge` service and dependency.
+-   Changed `stop` command to run `docker-compose stop` instead of `docker-compose down`
 
 ## [1.0.7] - June-22-2021
 

--- a/src/service/RunService.ts
+++ b/src/service/RunService.ts
@@ -211,7 +211,7 @@ export class RunService {
     }
 
     public async stop(): Promise<void> {
-        const args = ['down'];
+        const args = ['stop'];
         if (await this.beforeRun(args, true)) await this.basicRun(args);
     }
 


### PR DESCRIPTION
<docker-compose down> stops and removes the containers thus the files produced in the container get lost on each stop command.
We changed it to <docker-compose stop> in order to preserve the last state of the container and have a faster start-up.