### PR TITLE
fix: `updateVotingKeys` always returns the `Network preset could not be resolved!` error

### DIFF
--- a/src/commands/updateVotingKeys.ts
+++ b/src/commands/updateVotingKeys.ts
@@ -60,7 +60,7 @@ When a new voting file is created, Bootstrap will advise running the \`link\` co
         const root = this.config.root;
         const existingPreset = configLoader.loadExistingPresetData(target, password);
         const preset = existingPreset.preset;
-        if (preset) {
+        if (!preset) {
             throw new Error(`Network preset could not be resolved!`);
         }
         // Adds new shared/network properties to the existing preset. This is for upgrades..


### PR DESCRIPTION
This PR corrects the condition for determining when there is no network preset.
Closes #294

I'm not sure whether to make the PR base branch main or dev. Please let me know if there are any problems in merging.