### PR TITLE
fix: Fixed `symbol-statistics-service-typescript-fetch-client` exception handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.1.0] - NEXT
+## [1.1.1] - NEXT
 
-**Milestone**: Mainnet(1.0.2.0)
+**Milestone**: Mainnet(1.0.3.0)
+
+| Package          | Version | Link                                                               |
+| ---------------- | ------- | ------------------------------------------------------------------ |
+| Symbol Bootstrap | v1.1.1  | [symbol-bootstrap](https://www.npmjs.com/package/symbol-bootstrap) |
+
+- Fixed `symbol-statistics-service-typescript-fetch-client` exception handling.
+
+## [1.1.0] - Nov-05-2021
+
+**Milestone**: Mainnet(1.0.3.0)
 
 | Package          | Version | Link                                                               |
 | ---------------- | ------- | ------------------------------------------------------------------ |

--- a/package-lock.json
+++ b/package-lock.json
@@ -5294,9 +5294,9 @@
             }
         },
         "symbol-statistics-service-typescript-fetch-client": {
-            "version": "1.1.1-SNAPSHOT.202110302303",
-            "resolved": "https://registry.npmjs.org/symbol-statistics-service-typescript-fetch-client/-/symbol-statistics-service-typescript-fetch-client-1.1.1-SNAPSHOT.202110302303.tgz",
-            "integrity": "sha512-rFhjyOzkerFCk5S7enq6ugSf72Pa5ck3Cna6lXOBFFEiIKVkecQKm/anrcNFhs1ijhY53N6cJta/45mMJGXgiw=="
+            "version": "1.1.2-SNAPSHOT.202111101304",
+            "resolved": "https://registry.npmjs.org/symbol-statistics-service-typescript-fetch-client/-/symbol-statistics-service-typescript-fetch-client-1.1.2-SNAPSHOT.202111101304.tgz",
+            "integrity": "sha512-FECbp29XApnGGCH1OG8q6RpX5GXe3Jti6Ea39WSojwehUQWPB1MYLMdiF6o4qzUTZ45mWF5Gd0qng6KF6Gqu4A=="
         },
         "table": {
             "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "semver": "^7.3.5",
         "shx": "^0.3.2",
         "symbol-sdk": "^1.0.1",
-        "symbol-statistics-service-typescript-fetch-client": "^1.1.1-SNAPSHOT.202110302303",
+        "symbol-statistics-service-typescript-fetch-client": "^1.1.2-SNAPSHOT.202111101304",
         "tslib": "^1.13.0",
         "utf8": "^2.1.2",
         "winston": "^3.3.3"

--- a/src/service/RemoteNodeService.ts
+++ b/src/service/RemoteNodeService.ts
@@ -16,7 +16,7 @@
 import fetch from 'cross-fetch';
 import { lookup } from 'dns';
 import { ChainInfo, RepositoryFactory, RepositoryFactoryHttp, RoleType } from 'symbol-sdk';
-import { Configuration, NodeApi, NodeListFilter, RequestContext, RestClientUtils } from 'symbol-statistics-service-typescript-fetch-client';
+import { Configuration, NodeApi, NodeListFilter, RequestContext } from 'symbol-statistics-service-typescript-fetch-client';
 import { LogType } from '../logger';
 import Logger from '../logger/Logger';
 import LoggerFactory from '../logger/LoggerFactory';
@@ -198,8 +198,7 @@ export class RemoteNodeService {
                     })
                     .filter((peerInfo): peerInfo is PeerInfo => !!peerInfo);
                 knownPeers.push(...peerInfos);
-            } catch (e) {
-                const error = await RestClientUtils.getErrorFromFetchResponse(e);
+            } catch (error) {
                 logger.warn(
                     `There has been an error connecting to statistics ${statisticsServiceUrl}. Peers cannot be resolved! Error ${error.message}`,
                 );

--- a/test/service/RemoteNodeService.test.ts
+++ b/test/service/RemoteNodeService.test.ts
@@ -553,4 +553,32 @@ describe('RemoteNodeService', () => {
             },
         ]);
     });
+
+    it('getPeerInfos unknown statisticsServiceUrl', async () => {
+        presetData.statisticsServiceUrl = 'https://testnet.symbol.invalid';
+        const service = new RemoteNodeService(presetData, false);
+        const peerInfos = await service.getPeerInfos();
+        // only static nodes are returned when the statistics service client fails
+        expect(peerInfos).deep.eq([
+            {
+                publicKey: 'AAAAE7EAEEAE61EF0C50B4D05931F4325F69081B1B074D31E094C4B21E8CFB3D',
+                endpoint: { host: 'someStaticPeer', port: 7900 },
+                metadata: { name: 'someStaticPeer', roles: 'Peer,Api' },
+            },
+        ]);
+    });
+
+    it('getPeerInfos invalid statisticsServiceUrl path', async () => {
+        presetData.statisticsServiceUrl = 'https://testnet.symbol.services/invalid';
+        const service = new RemoteNodeService(presetData, false);
+        const peerInfos = await service.getPeerInfos();
+        // only static nodes are returned when the statistics service client fails
+        expect(peerInfos).deep.eq([
+            {
+                publicKey: 'AAAAE7EAEEAE61EF0C50B4D05931F4325F69081B1B074D31E094C4B21E8CFB3D',
+                endpoint: { host: 'someStaticPeer', port: 7900 },
+                metadata: { name: 'someStaticPeer', roles: 'Peer,Api' },
+            },
+        ]);
+    });
 });

--- a/test/service/RemoteNodeService.test.ts
+++ b/test/service/RemoteNodeService.test.ts
@@ -553,9 +553,8 @@ describe('RemoteNodeService', () => {
             },
         ]);
     });
-
-    it('getPeerInfos unknown statisticsServiceUrl', async () => {
-        presetData.statisticsServiceUrl = 'https://testnet.symbol.invalid';
+    const assertPeersOnInvalidUrl = async (statisticsServiceUrl: string) => {
+        presetData.statisticsServiceUrl = statisticsServiceUrl;
         const service = new RemoteNodeService(presetData, false);
         const peerInfos = await service.getPeerInfos();
         // only static nodes are returned when the statistics service client fails
@@ -566,19 +565,13 @@ describe('RemoteNodeService', () => {
                 metadata: { name: 'someStaticPeer', roles: 'Peer,Api' },
             },
         ]);
+    };
+
+    it('getPeerInfos unknown statisticsServiceUrl', async () => {
+        await assertPeersOnInvalidUrl('https://testnet.symbol.invalid');
     });
 
     it('getPeerInfos invalid statisticsServiceUrl path', async () => {
-        presetData.statisticsServiceUrl = 'https://testnet.symbol.services/invalid';
-        const service = new RemoteNodeService(presetData, false);
-        const peerInfos = await service.getPeerInfos();
-        // only static nodes are returned when the statistics service client fails
-        expect(peerInfos).deep.eq([
-            {
-                publicKey: 'AAAAE7EAEEAE61EF0C50B4D05931F4325F69081B1B074D31E094C4B21E8CFB3D',
-                endpoint: { host: 'someStaticPeer', port: 7900 },
-                metadata: { name: 'someStaticPeer', roles: 'Peer,Api' },
-            },
-        ]);
+        await assertPeersOnInvalidUrl('https://testnet.symbol.services/invalid');
     });
 });


### PR DESCRIPTION
Fixes https://github.com/symbol/symbol-bootstrap/issues/314

The issue wasn't the proxy, the issue was how the generated `symbol-statistics-service-typescript-fetch-client` handled errors. I have improved that library so the exceptions are handled internally. 

The plan is to move the rest-client generator to a submodule of  https://github.com/symbol/statistics-service that automatically builds clients when updating openapi.