### PR TITLE
Fix peers json not getting generated correctly.

### DIFF
--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -375,8 +375,8 @@ export class ConfigService {
         logger.info(`Generating ${name} server configuration`);
         await BootstrapUtils.generateConfiguration({ ...serverRecoveryConfig, ...templateContext }, copyFrom, serverConfig, excludeFiles);
 
-        const isApi = (nodePresetData: PeerInfo): boolean => nodePresetData.metadata.roles.includes('Api');
-        const peers = knownPeers.filter((peer) => isApi(peer) && peer.publicKey != account.main.publicKey);
+        const isPeer = (nodePresetData: PeerInfo): boolean => nodePresetData.metadata.roles.includes('Peer');
+        const peers = knownPeers.filter((peer) => isPeer(peer) && peer.publicKey != account.main.publicKey);
         const peersP2PFile = await this.generateP2PFile(
             peers,
             presetData.peersP2PListLimit,
@@ -385,7 +385,8 @@ export class ConfigService {
             'peers-p2p.json',
         );
 
-        const apiPeers = knownPeers.filter((peer) => !isApi(peer) && peer.publicKey != account.main.publicKey);
+        const isApi = (nodePresetData: PeerInfo): boolean => nodePresetData.metadata.roles.includes('Api');
+        const apiPeers = knownPeers.filter((peer) => isApi(peer) && peer.publicKey != account.main.publicKey);
         const peersApiFile = await this.generateP2PFile(
             apiPeers,
             presetData.peersApiListLimit,


### PR DESCRIPTION
The peers json files does not get generated correctly after the statistics service implementation.

The issues are
1. API nodes are been placed in peers-p2p.json
2. Nodes that are not API been put into the peers-api.json

For local network, peer-0 and peer-1 nodes were not able to discover each other.
For mainnet, this would most likely cause the peers-api.json to be empty due to the fact that most of the network is dual nodes(includes api).