### PR TITLE
fix: Removed npm module root folder location param.

### DIFF
--- a/src/commands/compose.ts
+++ b/src/commands/compose.ts
@@ -47,6 +47,6 @@ export default class Compose extends Command {
             CommandUtils.passwordPromptDefaultMessage,
             true,
         );
-        await new BootstrapService(this.config.root).compose(flags);
+        await new BootstrapService().compose(flags);
     }
 }

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -85,6 +85,6 @@ export default class Config extends Command {
             CommandUtils.passwordPromptDefaultMessage,
             true,
         );
-        await new BootstrapService(this.config.root).config(flags);
+        await new BootstrapService().config(flags);
     }
 }

--- a/src/commands/healthCheck.ts
+++ b/src/commands/healthCheck.ts
@@ -39,6 +39,6 @@ The health check process handles 'repeat' and custom 'openPort' services.
     public async run(): Promise<void> {
         const { flags } = this.parse(HealthCheck);
         BootstrapUtils.showBanner();
-        await new BootstrapService(this.config.root).healthCheck(flags);
+        await new BootstrapService().healthCheck(flags);
     }
 }

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -43,6 +43,6 @@ export default class Link extends Command {
             CommandUtils.passwordPromptDefaultMessage,
             true,
         );
-        return new BootstrapService(this.config.root).link(flags);
+        return new BootstrapService().link(flags);
     }
 }

--- a/src/commands/modifyMultisig.ts
+++ b/src/commands/modifyMultisig.ts
@@ -62,6 +62,6 @@ export default class ModifyMultisig extends Command {
             CommandUtils.passwordPromptDefaultMessage,
             true,
         );
-        return new BootstrapService(this.config.root).modifyMultisig(flags);
+        return new BootstrapService().modifyMultisig(flags);
     }
 }

--- a/src/commands/pack.ts
+++ b/src/commands/pack.ts
@@ -80,7 +80,7 @@ export default class Pack extends Command {
             CommandUtils.passwordPromptDefaultMessage,
             true,
         );
-        const service = await new BootstrapService(this.config.root);
+        const service = await new BootstrapService();
         const configOnlyCustomPresetFileName = 'config-only-custom-preset.yml';
         const configResult = await service.config(flags);
         await service.compose(flags, configResult.presetData);

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -31,6 +31,6 @@ export default class Clean extends Command {
     public async run(): Promise<void> {
         const { flags } = this.parse(Clean);
         BootstrapUtils.showBanner();
-        await new BootstrapService(this.config.root).report(flags);
+        await new BootstrapService().report(flags);
     }
 }

--- a/src/commands/resetData.ts
+++ b/src/commands/resetData.ts
@@ -31,6 +31,6 @@ export default class ResetData extends Command {
     public async run(): Promise<void> {
         const { flags } = this.parse(ResetData);
         BootstrapUtils.showBanner();
-        await new BootstrapService(this.config.root).resetData(flags);
+        await new BootstrapService().resetData(flags);
     }
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -66,6 +66,6 @@ export default class Run extends Command {
     public run(): Promise<void> {
         const { flags } = this.parse(Run);
         BootstrapUtils.showBanner();
-        return new BootstrapService(this.config.root).run(flags);
+        return new BootstrapService().run(flags);
     }
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -44,6 +44,6 @@ export default class Start extends Command {
             CommandUtils.passwordPromptDefaultMessage,
             true,
         );
-        await new BootstrapService(this.config.root).start(flags);
+        await new BootstrapService().start(flags);
     }
 }

--- a/src/commands/updateVotingKeys.ts
+++ b/src/commands/updateVotingKeys.ts
@@ -57,15 +57,14 @@ When a new voting file is created, Bootstrap will advise running the \`link\` co
         const target = flags.target;
         const configLoader = new ConfigLoader();
         const addressesLocation = configLoader.getGeneratedAddressLocation(target);
-        const root = this.config.root;
         const existingPreset = configLoader.loadExistingPresetData(target, password);
         const preset = existingPreset.preset;
         if (!preset) {
             throw new Error(`Network preset could not be resolved!`);
         }
         // Adds new shared/network properties to the existing preset. This is for upgrades..
-        const sharedPreset = BootstrapUtils.loadYaml(join(root, 'presets', 'shared.yml'), false);
-        const networkPreset = BootstrapUtils.loadYaml(`${root}/presets/${preset}/network.yml`, false);
+        const sharedPreset = BootstrapUtils.loadYaml(join(BootstrapUtils.ROOT_FOLDER, 'presets', 'shared.yml'), false);
+        const networkPreset = BootstrapUtils.loadYaml(join(BootstrapUtils.ROOT_FOLDER, 'presets', preset, 'network.yml'), false);
         const presetData = configLoader.mergePresets(sharedPreset, networkPreset, existingPreset) as ConfigPreset;
 
         const addresses = configLoader.loadExistingAddresses(target, password);

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -32,7 +32,7 @@ export default class Verify extends Command {
 
     public async run(): Promise<void> {
         BootstrapUtils.showBanner();
-        const report = await new VerifyService(this.config.root).createReport();
+        const report = await new VerifyService().createReport();
         logger.info(`OS: ${report.platform}`);
         report.lines.forEach((line) => {
             if (line.recommendation) {

--- a/src/commands/wizard.ts
+++ b/src/commands/wizard.ts
@@ -82,21 +82,18 @@ export default class Wizard extends Command {
 
     public async run(): Promise<void> {
         const flags = this.parse(Wizard).flags;
-        return Wizard.execute(this.config.root, flags);
+        return Wizard.execute(flags);
     }
 
-    public static async execute(
-        root: string,
-        flags: {
-            noPassword: boolean;
-            skipPull?: boolean;
-            target: string;
-            password: string | undefined;
-            network: Network | undefined;
-            customPreset: string;
-            ready?: boolean;
-        },
-    ): Promise<void> {
+    public static async execute(flags: {
+        noPassword: boolean;
+        skipPull?: boolean;
+        target: string;
+        password: string | undefined;
+        network: Network | undefined;
+        customPreset: string;
+        ready?: boolean;
+    }): Promise<void> {
         BootstrapUtils.showBanner();
         console.log('Welcome to the Symbol Bootstrap wizard! This command will:');
         console.log(' - Guide you through the configuration process.');

--- a/src/service/BootstrapService.ts
+++ b/src/service/BootstrapService.ts
@@ -15,7 +15,6 @@
  */
 
 import { Addresses, ConfigPreset, DockerCompose } from '../model';
-import { BootstrapUtils } from './BootstrapUtils';
 import { ComposeParams, ComposeService } from './ComposeService';
 import { ConfigParams, ConfigResult, ConfigService } from './ConfigService';
 import { LinkParams, LinkService } from './LinkService';
@@ -29,15 +28,13 @@ export type StartParams = ConfigParams & ComposeParams & RunParams;
  * Main entry point for API integration.
  */
 export class BootstrapService {
-    public constructor(private readonly root: string = BootstrapUtils.DEFAULT_ROOT_FOLDER) {}
-
     /**
      * It generates the configuration and nemesis for the provided preset
      *
      * @param config the params of the config command.
      */
     public async config(config: ConfigParams): Promise<ConfigResult> {
-        return new ConfigService(this.root, config).run();
+        return new ConfigService(config).run();
     }
 
     /**
@@ -46,7 +43,7 @@ export class BootstrapService {
      * @param config the params of the config command.
      */
     public resolveConfigPreset(config: ConfigParams): ConfigPreset {
-        return new ConfigService(this.root, config).resolveConfigPreset(false);
+        return new ConfigService(config).resolveConfigPreset(false);
     }
 
     /**
@@ -59,7 +56,7 @@ export class BootstrapService {
      * @param passedAddresses the created addresses if you know if, otherwise will load the latest one resolved form the target folder.
      */
     public compose(config: ComposeParams, passedPresetData?: ConfigPreset, passedAddresses?: Addresses): Promise<DockerCompose> {
-        return new ComposeService(this.root, config).run(passedPresetData, passedAddresses);
+        return new ComposeService(config).run(passedPresetData, passedAddresses);
     }
 
     /**
@@ -106,7 +103,7 @@ export class BootstrapService {
      * @return the paths of the created reports.
      */
     public async report(config: ReportParams, passedPresetData?: ConfigPreset): Promise<string[]> {
-        return new ReportService(this.root, config).run(passedPresetData);
+        return new ReportService(config).run(passedPresetData);
     }
 
     /**

--- a/src/service/BootstrapUtils.ts
+++ b/src/service/BootstrapUtils.ts
@@ -76,7 +76,10 @@ export class BootstrapUtils {
     private static readonly pulledImages: string[] = [];
 
     public static readonly VERSION = version;
-    public static readonly DEFAULT_ROOT_FOLDER = BootstrapUtils.resolveRootFolder();
+    /**
+     * The folder where this npm module is installed. It defines where the default presets, configurations, etc are located.
+     */
+    public static readonly ROOT_FOLDER = BootstrapUtils.resolveRootFolder();
 
     public static stopProcess = false;
 

--- a/src/service/CertificateService.ts
+++ b/src/service/CertificateService.ts
@@ -46,7 +46,7 @@ export interface NodeCertificates {
 export class CertificateService {
     private static readonly METADATA_VERSION = 1;
 
-    constructor(private readonly root: string, protected readonly params: CertificateParams) {}
+    constructor(protected readonly params: CertificateParams) {}
 
     public static getCertificates(stdout: string): CertificatePair[] {
         const locations = (string: string, substring: string): number[] => {
@@ -89,7 +89,7 @@ export class CertificateService {
         customCertFolder?: string,
         randomSerial?: string,
     ): Promise<void> {
-        const copyFrom = `${this.root}/config/cert`;
+        const copyFrom = join(BootstrapUtils.ROOT_FOLDER, `config`, `cert`);
         const certFolder = customCertFolder || BootstrapUtils.getTargetNodesFolder(this.params.target, false, name, 'cert');
 
         const metadataFile = join(certFolder, 'metadata.yml');

--- a/src/service/ComposeService.ts
+++ b/src/service/ComposeService.ts
@@ -54,7 +54,7 @@ export class ComposeService {
 
     private readonly configLoader: ConfigLoader;
 
-    constructor(private readonly root: string, protected readonly params: ComposeParams) {
+    constructor(protected readonly params: ComposeParams) {
         this.configLoader = new ConfigLoader();
     }
 
@@ -84,7 +84,7 @@ export class ComposeService {
         }
 
         await BootstrapUtils.mkdir(targetDocker);
-        await BootstrapUtils.generateConfiguration(presetData, join(this.root, 'config', 'docker'), targetDocker);
+        await BootstrapUtils.generateConfiguration(presetData, join(BootstrapUtils.ROOT_FOLDER, 'config', 'docker'), targetDocker);
 
         await BootstrapUtils.chmodRecursive(join(targetDocker, 'mongo'), 0o666);
 

--- a/src/service/ConfigLoader.ts
+++ b/src/service/ConfigLoader.ts
@@ -352,11 +352,11 @@ export class ConfigLoader {
         return BootstrapUtils.loadYaml(customPreset, password);
     }
 
-    private loadAssembly(root: string, preset: Preset, assembly: string | undefined): CustomPreset {
+    private loadAssembly(preset: Preset, assembly: string | undefined): CustomPreset {
         if (!assembly) {
             return {};
         }
-        const fileLocation = `${root}/presets/${preset}/assembly-${assembly}.yml`;
+        const fileLocation = join(BootstrapUtils.ROOT_FOLDER, 'presets', preset, `assembly-${assembly}.yml`);
         if (!existsSync(fileLocation)) {
             throw new KnownError(
                 `Assembly '${assembly}' is not valid for preset '${preset}'. Have you provided the right --preset <preset> --assembly <assembly> ?`,
@@ -380,7 +380,6 @@ export class ConfigLoader {
 
     public createPresetData(params: {
         password: Password;
-        root: string;
         preset?: Preset;
         assembly?: string;
         customPreset?: string;
@@ -401,10 +400,9 @@ export class ConfigLoader {
         const assembly =
             params.assembly || params.customPresetObject?.assembly || customPresetFileObject?.assembly || params.oldPresetData?.assembly;
 
-        const root = params.root;
-        const sharedPreset = BootstrapUtils.loadYaml(join(root, 'presets', 'shared.yml'), false);
-        const networkPreset = BootstrapUtils.loadYaml(`${root}/presets/${preset}/network.yml`, false);
-        const assemblyPreset = this.loadAssembly(root, preset, assembly);
+        const sharedPreset = BootstrapUtils.loadYaml(join(BootstrapUtils.ROOT_FOLDER, 'presets', 'shared.yml'), false);
+        const networkPreset = BootstrapUtils.loadYaml(join(BootstrapUtils.ROOT_FOLDER, 'presets', preset, 'network.yml'), false);
+        const assemblyPreset = this.loadAssembly(preset, assembly);
 
         const presetData = this.mergePresets(sharedPreset, networkPreset, assemblyPreset, customPresetFileObject, customPresetObject, {
             preset,

--- a/src/service/NemgenService.ts
+++ b/src/service/NemgenService.ts
@@ -42,7 +42,7 @@ export class NemgenService {
         const nemesisWorkingDir = BootstrapUtils.getTargetNemesisFolder(target, true);
         const nemesisSeedFolder = join(nemesisWorkingDir, `seed`, `${networkIdentifier}`, `0000`);
         await BootstrapUtils.mkdir(nemesisSeedFolder);
-        await promises.copyFile(join(this.root, `config`, `hashes.dat`), join(nemesisSeedFolder, `hashes.dat`));
+        await promises.copyFile(join(BootstrapUtils.ROOT_FOLDER, `config`, `hashes.dat`), join(nemesisSeedFolder, `hashes.dat`));
         const name = presetData.nodes[0].name;
         const serverConfigWorkingDir = BootstrapUtils.getTargetNodesFolder(target, true, name, 'server-config');
 

--- a/src/service/ReportService.ts
+++ b/src/service/ReportService.ts
@@ -56,7 +56,7 @@ export class ReportService {
         target: BootstrapUtils.defaultTargetFolder,
     };
     private readonly configLoader: ConfigLoader;
-    constructor(private readonly root: string, protected readonly params: ReportParams) {
+    constructor(protected readonly params: ReportParams) {
         this.configLoader = new ConfigLoader();
     }
 
@@ -100,7 +100,7 @@ export class ReportService {
     private async createReportsPerNode(presetData: ConfigPreset): Promise<ReportNode[]> {
         const workingDir = process.cwd();
         const target = join(workingDir, this.params.target);
-        const descriptions = await BootstrapUtils.loadYaml(join(this.root, 'presets', 'descriptions.yml'), false);
+        const descriptions = await BootstrapUtils.loadYaml(join(BootstrapUtils.ROOT_FOLDER, 'presets', 'descriptions.yml'), false);
         const promises: Promise<ReportNode>[] = (presetData.nodes || []).map(async (n) => {
             const resourcesFolder = join(BootstrapUtils.getTargetNodesFolder(target, false, n.name), 'server-config', 'resources');
             const files = await fsPromises.readdir(resourcesFolder);

--- a/src/service/VerifyService.ts
+++ b/src/service/VerifyService.ts
@@ -43,7 +43,7 @@ export class VerifyService {
     private readonly expectedVersions: ExpectedVersions;
     public readonly semverOptions = { loose: true };
 
-    constructor(private readonly root = BootstrapUtils.resolveRootFolder(), expectedVersions: Partial<ExpectedVersions> = {}) {
+    constructor(expectedVersions: Partial<ExpectedVersions> = {}) {
         this.expectedVersions = { ...defaultExpectedVersions, ...expectedVersions };
     }
 

--- a/test/commands/Wizard.test.ts
+++ b/test/commands/Wizard.test.ts
@@ -61,7 +61,7 @@ describe('Wizard', () => {
 
         const password = '11111';
         const customPresetFile = `${testFolder}/wizard-custom.yml`;
-        await Wizard.execute(BootstrapUtils.resolveRootFolder(), {
+        await Wizard.execute({
             customPreset: customPresetFile,
             network: Network.mainnet,
             noPassword: false,
@@ -119,7 +119,7 @@ describe('Wizard', () => {
 
         const customPresetFile = `${testFolder}/wizard-custom.yml`;
         const password = '11111';
-        await Wizard.execute(BootstrapUtils.resolveRootFolder(), {
+        await Wizard.execute({
             customPreset: customPresetFile,
             network: Network.mainnet,
             noPassword: false,
@@ -176,7 +176,7 @@ describe('Wizard', () => {
 
         const customPresetFile = `${testFolder}/wizard-custom.yml`;
         const password = '11111';
-        await Wizard.execute(BootstrapUtils.resolveRootFolder(), {
+        await Wizard.execute({
             customPreset: customPresetFile,
             network: Network.mainnet,
             noPassword: false,
@@ -241,7 +241,7 @@ describe('Wizard', () => {
 
         const customPresetFile = `${testFolder}/wizard-custom.yml`;
         const password = '11111';
-        await Wizard.execute(BootstrapUtils.resolveRootFolder(), {
+        await Wizard.execute({
             customPreset: customPresetFile,
             network: Network.mainnet,
             noPassword: false,

--- a/test/service/CertificateService.test.ts
+++ b/test/service/CertificateService.test.ts
@@ -42,9 +42,8 @@ describe('CertificateService', () => {
     it('createCertificates', async () => {
         const target = 'target/tests/CertificateService.test';
         await BootstrapUtils.deleteFolder(target);
-        const service = new CertificateService('.', { target: target, user: await BootstrapUtils.getDockerUserGroup() });
+        const service = new CertificateService({ target: target, user: await BootstrapUtils.getDockerUserGroup() });
         const presetData = new ConfigLoader().createPresetData({
-            root: '.',
             preset: Preset.bootstrap,
             password: 'abc',
         });

--- a/test/service/ComposeService.test.ts
+++ b/test/service/ComposeService.test.ts
@@ -25,9 +25,8 @@ describe('ComposeService', () => {
     const password = '1234';
 
     const assertDockerCompose = async (params: StartParams, expectedComposeFile: string) => {
-        const root = '.';
-        const presetData = new ConfigLoader().createPresetData({ root, password, ...params });
-        const dockerCompose = await new ComposeService(root, params).run(presetData);
+        const presetData = new ConfigLoader().createPresetData({ password, ...params });
+        const dockerCompose = await new ComposeService(params).run(presetData);
         Object.values(dockerCompose.services).forEach((service) => {
             if (service.mem_limit) {
                 service.mem_limit = 123;
@@ -285,7 +284,7 @@ ${BootstrapUtils.toYaml(dockerCompose)}
     });
 
     it('resolveDebugOptions', async () => {
-        const service = new ComposeService('.', ComposeService.defaultParams);
+        const service = new ComposeService(ComposeService.defaultParams);
         expect(service.resolveDebugOptions(true, true)).deep.equals(ComposeService.DEBUG_SERVICE_PARAMS);
         expect(service.resolveDebugOptions(true, undefined)).deep.equals(ComposeService.DEBUG_SERVICE_PARAMS);
         expect(service.resolveDebugOptions(true, false)).deep.equals({});

--- a/test/service/ConfigLoader.test.ts
+++ b/test/service/ConfigLoader.test.ts
@@ -36,7 +36,6 @@ describe('ConfigLoader', () => {
         const configLoader = new ConfigLoaderMocked();
         try {
             await configLoader.createPresetData({
-                root: '.',
                 preset: Preset.testnet,
                 assembly: undefined,
                 customPreset: undefined,
@@ -53,7 +52,6 @@ describe('ConfigLoader', () => {
     it('ConfigLoader loadPresetData testnet assembly', async () => {
         const configLoader = new ConfigLoaderMocked();
         const presetData = await configLoader.createPresetData({
-            root: '.',
             preset: Preset.testnet,
             assembly: 'dual',
             customPreset: undefined,
@@ -66,7 +64,6 @@ describe('ConfigLoader', () => {
     it('ConfigLoader loadPresetData bootstrap custom', async () => {
         const configLoader = new ConfigLoaderMocked();
         const presetData = await configLoader.createPresetData({
-            root: '.',
             preset: Preset.bootstrap,
             assembly: undefined,
             customPreset: 'test/override-currency-preset.yml',
@@ -83,7 +80,6 @@ describe('ConfigLoader', () => {
         const configLoader = new ConfigLoaderMocked();
         try {
             await configLoader.createPresetData({
-                root: '.',
                 preset: Preset.bootstrap,
                 assembly: undefined,
                 customPreset: 'test/override-currency-preset.yml',

--- a/test/service/ConfigService.test.ts
+++ b/test/service/ConfigService.test.ts
@@ -20,7 +20,7 @@ import { ConfigService, CryptoUtils, Preset } from '../../src/service';
 
 describe('ConfigService', () => {
     it('ConfigService default run with optin_preset.yml', async () => {
-        await new ConfigService('.', {
+        await new ConfigService({
             ...ConfigService.defaultParams,
             reset: true,
             target: 'target/tests/ConfigService.test.optin',
@@ -29,7 +29,7 @@ describe('ConfigService', () => {
     });
 
     it('ConfigService default run with override-currency-preset.yml', async () => {
-        await new ConfigService('.', {
+        await new ConfigService({
             ...ConfigService.defaultParams,
             reset: true,
             target: 'target/tests/ConfigService.test.custom',
@@ -38,7 +38,7 @@ describe('ConfigService', () => {
     });
 
     it('ConfigService testnet assembly', async () => {
-        await new ConfigService('.', {
+        await new ConfigService({
             ...ConfigService.defaultParams,
             reset: true,
             target: 'target/tests/ConfigService.test.testnet',
@@ -48,7 +48,7 @@ describe('ConfigService', () => {
     });
 
     it('ConfigService mainnet assembly', async () => {
-        await new ConfigService('.', {
+        await new ConfigService({
             ...ConfigService.defaultParams,
             reset: true,
             target: 'target/tests/ConfigService.test.mainnet',
@@ -58,14 +58,14 @@ describe('ConfigService', () => {
     });
 
     it('ConfigService bootstrap default', async () => {
-        const configResult = await new ConfigService('.', {
+        const configResult = await new ConfigService({
             ...ConfigService.defaultParams,
             reset: true,
             target: 'target/tests/bootstrap',
             preset: Preset.bootstrap,
         }).run();
 
-        const configResultUpgrade = await new ConfigService('.', {
+        const configResultUpgrade = await new ConfigService({
             ...ConfigService.defaultParams,
             upgrade: true,
             target: 'target/tests/bootstrap',
@@ -78,7 +78,7 @@ describe('ConfigService', () => {
     });
 
     it('ConfigService bootstrap repeat', async () => {
-        const configResult = await new ConfigService('.', {
+        const configResult = await new ConfigService({
             ...ConfigService.defaultParams,
             reset: true,
             target: 'target/tests/ConfigService.bootstrap.repeat',

--- a/test/service/ReportService.test.ts
+++ b/test/service/ReportService.test.ts
@@ -23,9 +23,9 @@ import { BootstrapUtils, ConfigParams, ConfigService, Preset, ReportService } fr
 
 describe('ReportService', () => {
     const assertReport = async (params: ConfigParams, expectedReportsFolder: string): Promise<void> => {
-        const configResult = await new ConfigService('.', { ...params, offline: true }).run();
+        const configResult = await new ConfigService({ ...params, offline: true }).run();
 
-        const paths = await new ReportService('.', params).run(configResult.presetData);
+        const paths = await new ReportService(params).run(configResult.presetData);
         const expectedReportFolder = `./test/reports/${expectedReportsFolder}`;
         await BootstrapUtils.mkdir(expectedReportFolder);
 

--- a/test/service/VerifyService.test.ts
+++ b/test/service/VerifyService.test.ts
@@ -16,7 +16,7 @@
 import { expect } from '@oclif/test';
 import * as os from 'os';
 import * as semver from 'semver';
-import { BootstrapUtils, VerifyService } from '../../src/service';
+import { VerifyService } from '../../src/service';
 
 describe('VerifyService', () => {
     const currentNodeJsVersion = process.versions.node;
@@ -70,7 +70,7 @@ describe('VerifyService', () => {
             docker: '21.4.0',
             dockerCompose: '1.29.5',
         };
-        const service = new VerifyService(BootstrapUtils.resolveRootFolder(), expectedVersions);
+        const service = new VerifyService(expectedVersions);
         const currentDockerVersion = await service.loadVersionFromCommand('docker --version');
         const currentDockerComposeVersion = await service.loadVersionFromCommand('docker-compose --version');
         expect(semver.valid(currentNodeJsVersion, service.semverOptions));


### PR DESCRIPTION
It can be resolved without client code intervention, it works better when bootstrap is installed as a library for an app.

Another pr for better custom app integration

To be merged after 1.1.1 release