### PR TITLE
Nemesis configuration improvements

### DIFF
--- a/src/model/Addresses.ts
+++ b/src/model/Addresses.ts
@@ -46,7 +46,6 @@ export interface NodeAccount {
 export interface MosaicAccounts {
     name: string;
     id: string;
-    type: 'currency' | 'harvest';
     accounts: ConfigAccount[];
 }
 

--- a/src/model/ConfigPreset.ts
+++ b/src/model/ConfigPreset.ts
@@ -33,6 +33,11 @@ export interface DockerServicePreset {
     dockerComposeDebugMode?: boolean;
 }
 
+export interface CurrencyDistribution {
+    address: string;
+    amount: number;
+}
+
 export interface MosaicPreset {
     name: string;
     repeat?: number;
@@ -44,8 +49,9 @@ export interface MosaicPreset {
     isTransferable: boolean;
     isSupplyMutable: boolean;
     isRestrictable: boolean;
-    accounts: number;
-    currencyDistributions: { address: string; amount: number }[];
+    // options are generate x random accounts or provide their accounts public keys.
+    accounts: number | string[];
+    currencyDistributions: CurrencyDistribution[];
 }
 
 export interface DatabasePreset extends DockerServicePreset {
@@ -57,7 +63,6 @@ export interface DatabasePreset extends DockerServicePreset {
 export interface NemesisPreset {
     binDirectory: string;
     mosaics: MosaicPreset[];
-    balances?: Record<string, number>;
     transactions?: Record<string, string>;
     nemesisSignerPrivateKey: string;
     transactionsDirectory: string;
@@ -259,6 +264,7 @@ export interface NodePreset extends DockerServicePreset, Partial<NodeConfigPrese
     host?: string;
     roles?: string;
     friendlyName?: string;
+    excludeFromNemesis: boolean;
 
     // Optional private keys. If not provided, bootstrap will generate random ones.
     mainPrivateKey?: string;
@@ -272,6 +278,8 @@ export interface NodePreset extends DockerServicePreset, Partial<NodeConfigPrese
 
     vrfPrivateKey?: string;
     vrfPublicKey?: string;
+
+    balances?: number[];
 
     //Broker specific
     brokerName?: string;
@@ -416,9 +424,6 @@ export interface CommonConfigPreset extends NodeConfigPreset, GatewayConfigPrese
     currencyMosaicId: string;
     harvestingMosaicId: string;
     baseNamespace: string;
-    // This next 2 would be removed in a later merge.
-    currencyName?: string;
-    harvestingName?: string;
     networkType: NetworkType;
     votingKeyDesiredLifetime: number;
     votingKeyDesiredFutureLifetime: number; // How in the future voting key files need to be generated. By default, 1 months before expiring..

--- a/src/service/ConfigLoader.ts
+++ b/src/service/ConfigLoader.ts
@@ -156,7 +156,7 @@ export class ConfigLoader {
         const networkType = presetData.networkType;
         const mosaics: MosaicAccounts[] = [];
         presetData.nemesis.mosaics.forEach((m, mosaicIndex) => {
-            const accounts = this.generateAddresses(networkType, privateKeySecurityMode, m.accounts || 1);
+            const accounts = this.generateAddresses(networkType, privateKeySecurityMode, m.accounts);
             const id = MosaicId.createFromNonce(MosaicNonce.createFromNumber(mosaicIndex), nemesisSignerAddress).toHex();
             mosaics.push({
                 id: id,

--- a/test/service/ConfigService.test.ts
+++ b/test/service/ConfigService.test.ts
@@ -337,6 +337,142 @@ describe('ConfigService', () => {
         );
     });
 
+    it('ConfigService resolve nemesis balances no extra generated accounts', async () => {
+        const customPresetObject: CustomPreset = {
+            nodes: [
+                {
+                    mainPrivateKey: '0000000000000000000000000000000000000000000000000000000000000001',
+                },
+            ],
+            nemesis: {
+                nemesisSignerPrivateKey: '935C58E9D933D9A4E3BE6EEB5DA7B518FF90DA6B32BA6BEDE1098B79E2B69B66',
+                mosaics: [
+                    {
+                        accounts: 0,
+                        currencyDistributions: [
+                            {
+                                address: 'TACBGHDQEJOAOAIR4KGWWAOZRGGSR4BPR6JRCPI',
+                                amount: 10,
+                            },
+                            {
+                                address: 'TBJEKGLTINMGFEH6O47E7ZXMZFWZAJHBJTHOVUY',
+                                amount: 20,
+                            },
+                        ],
+                    },
+                    {
+                        name: 'harvest',
+                        accounts: 0,
+                        currencyDistributions: [
+                            {
+                                address: 'TDSDCOH77Z27YCQ4NPDNC6MMVHXFGIQ7AV4JQSI',
+                                amount: 100,
+                            },
+                            {
+                                address: 'TDEOPVFMZW4CEY5OHSGTT3DKTU2JLF2HN57K6AY',
+                                amount: 200,
+                            },
+                            {
+                                address: 'TCHX23ENEKTSUGI7MMXFFALNF57C6WXBL7VXM7I',
+                                amount: 300,
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+        const configResult = await new ConfigService(logger, {
+            ...ConfigService.defaultParams,
+            reset: true,
+            target: 'target/tests/ConfigService.bootstrap.nemesis.balances.no.extra.gen.accounts',
+            preset: Preset.bootstrap,
+            assembly: Assembly.dual,
+            customPresetObject: customPresetObject,
+        }).run();
+        const presetData = configResult.presetData;
+        expect(presetData.nemesis).deep.eq(
+            {
+                mosaics: [
+                    {
+                        name: 'currency',
+                        divisibility: 6,
+                        duration: 0,
+                        supply: 8998999998000000,
+                        isTransferable: true,
+                        isSupplyMutable: false,
+                        isRestrictable: false,
+                        accounts: 0,
+                        currencyDistributions: [
+                            {
+                                address: 'TB6QOVCUOFRCF5QJSKPIQMLUVWGJS3KYFDETRPA',
+                                amount: 8998999997999970,
+                            },
+                            {
+                                address: 'TACBGHDQEJOAOAIR4KGWWAOZRGGSR4BPR6JRCPI',
+                                amount: 10,
+                            },
+                            {
+                                address: 'TBJEKGLTINMGFEH6O47E7ZXMZFWZAJHBJTHOVUY',
+                                amount: 20,
+                            },
+                        ],
+                    },
+                    {
+                        name: 'harvest',
+                        divisibility: 3,
+                        duration: 0,
+                        supply: 15000000,
+                        isTransferable: true,
+                        isSupplyMutable: true,
+                        isRestrictable: false,
+                        accounts: 0,
+                        currencyDistributions: [
+                            {
+                                address: 'TB6QOVCUOFRCF5QJSKPIQMLUVWGJS3KYFDETRPA',
+                                amount: 14999400,
+                            },
+                            {
+                                address: 'TDSDCOH77Z27YCQ4NPDNC6MMVHXFGIQ7AV4JQSI',
+                                amount: 100,
+                            },
+                            {
+                                address: 'TDEOPVFMZW4CEY5OHSGTT3DKTU2JLF2HN57K6AY',
+                                amount: 200,
+                            },
+                            {
+                                address: 'TCHX23ENEKTSUGI7MMXFFALNF57C6WXBL7VXM7I',
+                                amount: 300,
+                            },
+                        ],
+                    },
+                ],
+                nemesisSignerPrivateKey: '935C58E9D933D9A4E3BE6EEB5DA7B518FF90DA6B32BA6BEDE1098B79E2B69B66',
+            },
+            `Should be the same than  \n${JSON.stringify(presetData.nemesis, null, 2)}`,
+        );
+
+        expect(presetData.nemesis.mosaics.length).eq(2);
+        presetData.nemesis.mosaics.forEach((mosaic) => {
+            expect(_.sumBy(mosaic.currencyDistributions, (d) => d.amount)).eq(mosaic.supply);
+        });
+
+        expect(configResult.addresses.mosaics).deep.eq(
+            [
+                {
+                    id: '113DFC906359F64D',
+                    name: 'currency',
+                    accounts: [],
+                },
+                {
+                    id: '0B2720BC49498DAC',
+                    name: 'harvest',
+                    accounts: [],
+                },
+            ],
+            `Should be the same than  \n${JSON.stringify(configResult.addresses.mosaics, null, 2)}`,
+        );
+    });
+
     it('ConfigService resolve nemesis balances when excluding the node', async () => {
         const customPresetObject: CustomPreset = {
             nodes: [

--- a/test/service/ConfigService.test.ts
+++ b/test/service/ConfigService.test.ts
@@ -15,9 +15,10 @@
  */
 
 import { expect } from '@oclif/test';
+import * as _ from 'lodash';
 import 'mocha';
 import { join } from 'path';
-import { Assembly, LoggerFactory, LogType } from '../../src';
+import { Assembly, CustomPreset, LoggerFactory, LogType } from '../../src';
 import { ConfigService, CryptoUtils, Preset } from '../../src/service';
 // Local test utils
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -156,5 +157,417 @@ describe('ConfigService', () => {
         assertRepeatedService(7, configResult.presetData.nodes);
         assertRepeatedService(4, configResult.presetData.gateways);
         assertRepeatedService(4, configResult.presetData.databases);
+    });
+
+    it('ConfigService resolve nemesis balances', async () => {
+        const customPresetObject: CustomPreset = {
+            nodes: [
+                {
+                    mainPrivateKey: '0000000000000000000000000000000000000000000000000000000000000001',
+                },
+            ],
+            nemesis: {
+                nemesisSignerPrivateKey: '935C58E9D933D9A4E3BE6EEB5DA7B518FF90DA6B32BA6BEDE1098B79E2B69B66',
+                mosaics: [
+                    {
+                        accounts: [
+                            '000000000000000000000000000000000000000000000000000000000000000A',
+                            '000000000000000000000000000000000000000000000000000000000000000B',
+                            '000000000000000000000000000000000000000000000000000000000000000C',
+                        ],
+                        currencyDistributions: [
+                            {
+                                address: 'TACBGHDQEJOAOAIR4KGWWAOZRGGSR4BPR6JRCPI',
+                                amount: 10,
+                            },
+                            {
+                                address: 'TBJEKGLTINMGFEH6O47E7ZXMZFWZAJHBJTHOVUY',
+                                amount: 20,
+                            },
+                        ],
+                    },
+                    {
+                        name: 'harvest',
+                        accounts: ['000000000000000000000000000000000000000000000000000000000000000D'],
+                        currencyDistributions: [
+                            {
+                                address: 'TDSDCOH77Z27YCQ4NPDNC6MMVHXFGIQ7AV4JQSI',
+                                amount: 100,
+                            },
+                            {
+                                address: 'TDEOPVFMZW4CEY5OHSGTT3DKTU2JLF2HN57K6AY',
+                                amount: 200,
+                            },
+                            {
+                                address: 'TCHX23ENEKTSUGI7MMXFFALNF57C6WXBL7VXM7I',
+                                amount: 300,
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+        const configResult = await new ConfigService(logger, {
+            ...ConfigService.defaultParams,
+            reset: true,
+            target: 'target/tests/ConfigService.bootstrap.nemesis.balances',
+            preset: Preset.bootstrap,
+            assembly: Assembly.dual,
+            customPresetObject: customPresetObject,
+        }).run();
+        const presetData = configResult.presetData;
+        expect(presetData.nemesis).deep.eq(
+            {
+                mosaics: [
+                    {
+                        name: 'currency',
+                        divisibility: 6,
+                        duration: 0,
+                        supply: 8998999998000000,
+                        isTransferable: true,
+                        isSupplyMutable: false,
+                        isRestrictable: false,
+                        accounts: [
+                            '000000000000000000000000000000000000000000000000000000000000000A',
+                            '000000000000000000000000000000000000000000000000000000000000000B',
+                            '000000000000000000000000000000000000000000000000000000000000000C',
+                        ],
+                        currencyDistributions: [
+                            {
+                                address: 'TDSIJBWRFPA57RLKZQ4OTMLEHYT4L2MMMBSPGWA',
+                                amount: 2249749999499994,
+                            },
+                            {
+                                address: 'TCZTFCI4CFLHEB2KZX3GJO2IR6OV6SYUASPLAOA',
+                                amount: 2249749999499992,
+                            },
+                            {
+                                address: 'TBRZ247CV76OV6D75JT2KWYPUOEWAGEDBNKNVKQ',
+                                amount: 2249749999499992,
+                            },
+                            {
+                                address: 'TB6QOVCUOFRCF5QJSKPIQMLUVWGJS3KYFDETRPA',
+                                amount: 2249749999499992,
+                            },
+                            {
+                                address: 'TACBGHDQEJOAOAIR4KGWWAOZRGGSR4BPR6JRCPI',
+                                amount: 10,
+                            },
+                            {
+                                address: 'TBJEKGLTINMGFEH6O47E7ZXMZFWZAJHBJTHOVUY',
+                                amount: 20,
+                            },
+                        ],
+                    },
+                    {
+                        name: 'harvest',
+                        divisibility: 3,
+                        duration: 0,
+                        supply: 15000000,
+                        isTransferable: true,
+                        isSupplyMutable: true,
+                        isRestrictable: false,
+                        accounts: ['000000000000000000000000000000000000000000000000000000000000000D'],
+                        currencyDistributions: [
+                            {
+                                address: 'TDNLZGEP733XMNHH6Y5KGPSR7A3ZKJ6OF54ZWTQ',
+                                amount: 7499700,
+                            },
+                            {
+                                address: 'TB6QOVCUOFRCF5QJSKPIQMLUVWGJS3KYFDETRPA',
+                                amount: 7499700,
+                            },
+                            {
+                                address: 'TDSDCOH77Z27YCQ4NPDNC6MMVHXFGIQ7AV4JQSI',
+                                amount: 100,
+                            },
+                            {
+                                address: 'TDEOPVFMZW4CEY5OHSGTT3DKTU2JLF2HN57K6AY',
+                                amount: 200,
+                            },
+                            {
+                                address: 'TCHX23ENEKTSUGI7MMXFFALNF57C6WXBL7VXM7I',
+                                amount: 300,
+                            },
+                        ],
+                    },
+                ],
+                nemesisSignerPrivateKey: '935C58E9D933D9A4E3BE6EEB5DA7B518FF90DA6B32BA6BEDE1098B79E2B69B66',
+            },
+            `Should be the same than  \n${JSON.stringify(presetData.nemesis, null, 2)}`,
+        );
+
+        expect(presetData.nemesis.mosaics.length).eq(2);
+        presetData.nemesis.mosaics.forEach((mosaic) => {
+            expect(_.sumBy(mosaic.currencyDistributions, (d) => d.amount)).eq(mosaic.supply);
+        });
+
+        expect(configResult.addresses.mosaics).deep.eq(
+            [
+                {
+                    id: '113DFC906359F64D',
+                    name: 'currency',
+                    accounts: [
+                        {
+                            publicKey: '000000000000000000000000000000000000000000000000000000000000000A',
+                            address: 'TDSIJBWRFPA57RLKZQ4OTMLEHYT4L2MMMBSPGWA',
+                        },
+                        {
+                            publicKey: '000000000000000000000000000000000000000000000000000000000000000B',
+                            address: 'TCZTFCI4CFLHEB2KZX3GJO2IR6OV6SYUASPLAOA',
+                        },
+                        {
+                            publicKey: '000000000000000000000000000000000000000000000000000000000000000C',
+                            address: 'TBRZ247CV76OV6D75JT2KWYPUOEWAGEDBNKNVKQ',
+                        },
+                    ],
+                },
+                {
+                    id: '0B2720BC49498DAC',
+                    name: 'harvest',
+                    accounts: [
+                        {
+                            publicKey: '000000000000000000000000000000000000000000000000000000000000000D',
+                            address: 'TDNLZGEP733XMNHH6Y5KGPSR7A3ZKJ6OF54ZWTQ',
+                        },
+                    ],
+                },
+            ],
+            `Should be the same than  \n${JSON.stringify(configResult.addresses.mosaics, null, 2)}`,
+        );
+    });
+
+    it('ConfigService resolve nemesis balances when excluding the node', async () => {
+        const customPresetObject: CustomPreset = {
+            nodes: [
+                {
+                    excludeFromNemesis: true,
+                },
+            ],
+            nemesis: {
+                nemesisSignerPrivateKey: '935C58E9D933D9A4E3BE6EEB5DA7B518FF90DA6B32BA6BEDE1098B79E2B69B66',
+                mosaics: [
+                    {
+                        accounts: [
+                            '000000000000000000000000000000000000000000000000000000000000000A',
+                            '000000000000000000000000000000000000000000000000000000000000000B',
+                            '000000000000000000000000000000000000000000000000000000000000000C',
+                        ],
+                        currencyDistributions: [
+                            {
+                                address: 'TACBGHDQEJOAOAIR4KGWWAOZRGGSR4BPR6JRCPI',
+                                amount: 10,
+                            },
+                            {
+                                address: 'TBJEKGLTINMGFEH6O47E7ZXMZFWZAJHBJTHOVUY',
+                                amount: 20,
+                            },
+                        ],
+                    },
+                    {
+                        name: 'harvest',
+                        accounts: ['000000000000000000000000000000000000000000000000000000000000000D'],
+                        currencyDistributions: [
+                            {
+                                address: 'TDSDCOH77Z27YCQ4NPDNC6MMVHXFGIQ7AV4JQSI',
+                                amount: 100,
+                            },
+                            {
+                                address: 'TDEOPVFMZW4CEY5OHSGTT3DKTU2JLF2HN57K6AY',
+                                amount: 200,
+                            },
+                            {
+                                address: 'TCHX23ENEKTSUGI7MMXFFALNF57C6WXBL7VXM7I',
+                                amount: 300,
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+        const configResult = await new ConfigService(logger, {
+            ...ConfigService.defaultParams,
+            reset: true,
+            target: 'target/tests/ConfigService.bootstrap.nemesis.balances',
+            preset: Preset.bootstrap,
+            assembly: Assembly.dual,
+            customPresetObject: customPresetObject,
+        }).run();
+        const presetData = configResult.presetData;
+        expect(presetData.nemesis).deep.eq(
+            {
+                mosaics: [
+                    {
+                        name: 'currency',
+                        divisibility: 6,
+                        duration: 0,
+                        supply: 8998999998000000,
+                        isTransferable: true,
+                        isSupplyMutable: false,
+                        isRestrictable: false,
+                        accounts: [
+                            '000000000000000000000000000000000000000000000000000000000000000A',
+                            '000000000000000000000000000000000000000000000000000000000000000B',
+                            '000000000000000000000000000000000000000000000000000000000000000C',
+                        ],
+                        currencyDistributions: [
+                            {
+                                address: 'TDSIJBWRFPA57RLKZQ4OTMLEHYT4L2MMMBSPGWA',
+                                amount: 2999666665999990,
+                            },
+                            {
+                                address: 'TCZTFCI4CFLHEB2KZX3GJO2IR6OV6SYUASPLAOA',
+                                amount: 2999666665999990,
+                            },
+                            {
+                                address: 'TBRZ247CV76OV6D75JT2KWYPUOEWAGEDBNKNVKQ',
+                                amount: 2999666665999990,
+                            },
+                            {
+                                address: 'TACBGHDQEJOAOAIR4KGWWAOZRGGSR4BPR6JRCPI',
+                                amount: 10,
+                            },
+                            {
+                                address: 'TBJEKGLTINMGFEH6O47E7ZXMZFWZAJHBJTHOVUY',
+                                amount: 20,
+                            },
+                        ],
+                    },
+                    {
+                        name: 'harvest',
+                        divisibility: 3,
+                        duration: 0,
+                        supply: 15000000,
+                        isTransferable: true,
+                        isSupplyMutable: true,
+                        isRestrictable: false,
+                        accounts: ['000000000000000000000000000000000000000000000000000000000000000D'],
+                        currencyDistributions: [
+                            {
+                                address: 'TDNLZGEP733XMNHH6Y5KGPSR7A3ZKJ6OF54ZWTQ',
+                                amount: 14999400,
+                            },
+                            {
+                                address: 'TDSDCOH77Z27YCQ4NPDNC6MMVHXFGIQ7AV4JQSI',
+                                amount: 100,
+                            },
+                            {
+                                address: 'TDEOPVFMZW4CEY5OHSGTT3DKTU2JLF2HN57K6AY',
+                                amount: 200,
+                            },
+                            {
+                                address: 'TCHX23ENEKTSUGI7MMXFFALNF57C6WXBL7VXM7I',
+                                amount: 300,
+                            },
+                        ],
+                    },
+                ],
+                nemesisSignerPrivateKey: '935C58E9D933D9A4E3BE6EEB5DA7B518FF90DA6B32BA6BEDE1098B79E2B69B66',
+            },
+            `Should be the same than  \n${JSON.stringify(presetData.nemesis, null, 2)}`,
+        );
+
+        expect(presetData.nemesis.mosaics.length).eq(2);
+        presetData.nemesis.mosaics.forEach((mosaic) => {
+            expect(_.sumBy(mosaic.currencyDistributions, (d) => d.amount)).eq(mosaic.supply);
+        });
+
+        expect(configResult.addresses.mosaics).deep.eq(
+            [
+                {
+                    id: '113DFC906359F64D',
+                    name: 'currency',
+                    accounts: [
+                        {
+                            publicKey: '000000000000000000000000000000000000000000000000000000000000000A',
+                            address: 'TDSIJBWRFPA57RLKZQ4OTMLEHYT4L2MMMBSPGWA',
+                        },
+                        {
+                            publicKey: '000000000000000000000000000000000000000000000000000000000000000B',
+                            address: 'TCZTFCI4CFLHEB2KZX3GJO2IR6OV6SYUASPLAOA',
+                        },
+                        {
+                            publicKey: '000000000000000000000000000000000000000000000000000000000000000C',
+                            address: 'TBRZ247CV76OV6D75JT2KWYPUOEWAGEDBNKNVKQ',
+                        },
+                    ],
+                },
+                {
+                    id: '0B2720BC49498DAC',
+                    name: 'harvest',
+                    accounts: [
+                        {
+                            publicKey: '000000000000000000000000000000000000000000000000000000000000000D',
+                            address: 'TDNLZGEP733XMNHH6Y5KGPSR7A3ZKJ6OF54ZWTQ',
+                        },
+                    ],
+                },
+            ],
+            `Should be the same than  \n${JSON.stringify(configResult.addresses.mosaics, null, 2)}`,
+        );
+    });
+
+    it('ConfigService invalid nemesis balances, larger than supply', async () => {
+        const toKey = (prefix: string, keySize = 64): string => {
+            return prefix.padStart(keySize, '0');
+        };
+        const customPresetObject: CustomPreset = {
+            nodes: [
+                {
+                    mainPrivateKey: toKey('1'),
+                },
+            ],
+            nemesis: {
+                nemesisSignerPrivateKey: '935C58E9D933D9A4E3BE6EEB5DA7B518FF90DA6B32BA6BEDE1098B79E2B69B66',
+                mosaics: [
+                    {
+                        supply: 1000000,
+                        accounts: [toKey('A'), toKey('B'), toKey('C')],
+                        currencyDistributions: [
+                            {
+                                address: 'TACBGHDQEJOAOAIR4KGWWAOZRGGSR4BPR6JRCPI',
+                                amount: 999995,
+                            },
+                            {
+                                address: 'TBJEKGLTINMGFEH6O47E7ZXMZFWZAJHBJTHOVUY',
+                                amount: 10,
+                            },
+                        ],
+                    },
+                    {
+                        supply: 5000000,
+                        accounts: [toKey('D')],
+                        currencyDistributions: [
+                            {
+                                address: 'TDSDCOH77Z27YCQ4NPDNC6MMVHXFGIQ7AV4JQSI',
+                                amount: 100,
+                            },
+                            {
+                                address: 'TDEOPVFMZW4CEY5OHSGTT3DKTU2JLF2HN57K6AY',
+                                amount: 200,
+                            },
+                            {
+                                address: 'TCHX23ENEKTSUGI7MMXFFALNF57C6WXBL7VXM7I',
+                                amount: 300,
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+
+        try {
+            await new ConfigService(logger, {
+                ...ConfigService.defaultParams,
+                reset: true,
+                target: 'target/tests/ConfigService.bootstrap.invalid.nemesis.balances',
+                preset: Preset.bootstrap,
+                assembly: Assembly.dual,
+                customPresetObject: customPresetObject,
+            }).run();
+            expect(false).to.be.eq(true); // should have raised an error!
+        } catch (e) {
+            expect(e.message).eq("Mosaic currency's fixed distributed supply 1000005 is grater than mosaic total supply 1000000");
+        }
     });
 });


### PR DESCRIPTION
~1. Fixed config/start --preset and --assembly options (it was the other way around)~ Already merged in another pr
2. Removed unnecessary currency names from custom preset. It can be provided and resolved from the `nemesis.mosaics` field
3. Moved "opt-in" addresses/balances from `nemesis` to `nemesis.mosiac`. User (or symbol-network) can provide balances for multiple mosaics, although most of the time there is only one nemesis mosaic (like xym).
4. Allow a node to be excluded from nemesis (no balance or linked transactions). 
5. Allow users to provide node nemesis balance. If the balance is calculated, it will be less than  `maxHarvesterBalance` 
6. Better nemesis supply distribution and exception handling. Added unit tests.  

If this is too much I can split further. Note I would be creating a new PR where the genesis related configuration is moved to their own class/service