### PR TITLE
fix: voting key file provider

### DIFF
--- a/src/service/ConfigService.ts
+++ b/src/service/ConfigService.ts
@@ -40,8 +40,8 @@ import { ConfigLoader } from './ConfigLoader';
 import { CryptoUtils } from './CryptoUtils';
 import { NemgenService } from './NemgenService';
 import { RemoteNodeService } from './RemoteNodeService';
-import { ReportService } from './ReportService';
-import { VotingService } from './VotingService';
+import { ReportParams, ReportService } from './ReportService';
+import { VotingParams, VotingService } from './VotingService';
 
 /**
  * Defined presets.
@@ -75,7 +75,7 @@ export enum KeyName {
     ServiceProvider = 'Service Provider',
 }
 
-export interface ConfigParams {
+export interface ConfigParams extends VotingParams, ReportParams {
     report: boolean;
     reset: boolean;
     upgrade: boolean;

--- a/src/service/VotingKeyFileProvider.ts
+++ b/src/service/VotingKeyFileProvider.ts
@@ -19,7 +19,7 @@ import { Account } from 'symbol-sdk';
 import { Logger } from '../logger';
 import { ConfigPreset, NodeAccount, NodePreset } from '../model';
 import { BootstrapUtils } from './BootstrapUtils';
-import { VotingKeyFile, VotingUtils } from './VotingUtils';
+import { VotingUtils } from './VotingUtils';
 
 export interface VotingKeyParams {
     presetData: ConfigPreset;
@@ -31,8 +31,12 @@ export interface VotingKeyParams {
     votingKeyEndEpoch: number;
 }
 
+export interface VotingKeyCreationResult {
+    publicKey: string;
+}
+
 export interface VotingKeyFileProvider {
-    createVotingFile(params: VotingKeyParams): Promise<VotingKeyFile>;
+    createVotingFile(params: VotingKeyParams): Promise<VotingKeyCreationResult>;
 }
 
 export class NativeVotingKeyFileProvider implements VotingKeyFileProvider {
@@ -43,7 +47,7 @@ export class NativeVotingKeyFileProvider implements VotingKeyFileProvider {
         privateKeyTreeFileName,
         votingKeyStartEpoch,
         votingKeyEndEpoch,
-    }: VotingKeyParams): Promise<VotingKeyFile> {
+    }: VotingKeyParams): Promise<VotingKeyCreationResult> {
         const votingAccount = Account.generateNewAccount(presetData.networkType);
         const votingPrivateKey = votingAccount.privateKey;
         const votingUtils = new VotingUtils();
@@ -52,9 +56,6 @@ export class NativeVotingKeyFileProvider implements VotingKeyFileProvider {
         writeFileSync(join(votingKeysFolder, privateKeyTreeFileName), votingFile);
         return {
             publicKey: votingAccount.publicKey,
-            startEpoch: votingKeyStartEpoch,
-            endEpoch: votingKeyEndEpoch,
-            filename: privateKeyTreeFileName,
         };
     }
 }
@@ -67,7 +68,7 @@ export class CatapultVotingKeyFileProvider implements VotingKeyFileProvider {
         privateKeyTreeFileName,
         votingKeyStartEpoch,
         votingKeyEndEpoch,
-    }: VotingKeyParams): Promise<VotingKeyFile> {
+    }: VotingKeyParams): Promise<VotingKeyCreationResult> {
         this.logger.info(`Voting file is created using docker and catapult.tools.votingkey`);
         const votingAccount = Account.generateNewAccount(presetData.networkType);
         const votingPrivateKey = votingAccount.privateKey;
@@ -96,9 +97,6 @@ export class CatapultVotingKeyFileProvider implements VotingKeyFileProvider {
         }
         return {
             publicKey: votingAccount.publicKey,
-            startEpoch: votingKeyStartEpoch,
-            endEpoch: votingKeyEndEpoch,
-            filename: privateKeyTreeFileName,
         };
     }
 }

--- a/src/service/VotingKeyFileProvider.ts
+++ b/src/service/VotingKeyFileProvider.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+import { Account } from 'symbol-sdk';
+import { Logger } from '../logger';
+import { ConfigPreset, NodeAccount, NodePreset } from '../model';
+import { BootstrapUtils } from './BootstrapUtils';
+import { VotingKeyFile, VotingUtils } from './VotingUtils';
+
+export interface VotingKeyParams {
+    presetData: ConfigPreset;
+    nodeAccount: NodeAccount;
+    nodePreset: NodePreset;
+    votingKeysFolder: string;
+    privateKeyTreeFileName: string;
+    votingKeyStartEpoch: number;
+    votingKeyEndEpoch: number;
+}
+
+export interface VotingKeyFileProvider {
+    createVotingFile(params: VotingKeyParams): Promise<VotingKeyFile>;
+}
+
+export class NativeVotingKeyFileProvider implements VotingKeyFileProvider {
+    constructor(private readonly logger: Logger) {}
+    public async createVotingFile({
+        presetData,
+        votingKeysFolder,
+        privateKeyTreeFileName,
+        votingKeyStartEpoch,
+        votingKeyEndEpoch,
+    }: VotingKeyParams): Promise<VotingKeyFile> {
+        const votingAccount = Account.generateNewAccount(presetData.networkType);
+        const votingPrivateKey = votingAccount.privateKey;
+        const votingUtils = new VotingUtils();
+        this.logger.info('Voting file is created using the native typescript voting key file generator!');
+        const votingFile = await votingUtils.createVotingFile(votingPrivateKey, votingKeyStartEpoch, votingKeyEndEpoch);
+        writeFileSync(join(votingKeysFolder, privateKeyTreeFileName), votingFile);
+        return {
+            publicKey: votingAccount.publicKey,
+            startEpoch: votingKeyStartEpoch,
+            endEpoch: votingKeyEndEpoch,
+            filename: privateKeyTreeFileName,
+        };
+    }
+}
+
+export class CatapultVotingKeyFileProvider implements VotingKeyFileProvider {
+    constructor(private readonly logger: Logger, private readonly user: string) {}
+    public async createVotingFile({
+        presetData,
+        votingKeysFolder,
+        privateKeyTreeFileName,
+        votingKeyStartEpoch,
+        votingKeyEndEpoch,
+    }: VotingKeyParams): Promise<VotingKeyFile> {
+        this.logger.info(`Voting file is created using docker and catapult.tools.votingkey`);
+        const votingAccount = Account.generateNewAccount(presetData.networkType);
+        const votingPrivateKey = votingAccount.privateKey;
+        const symbolServerImage = presetData.symbolServerImage;
+        const binds = [`${votingKeysFolder}:/votingKeys:rw`];
+        const cmd = [
+            `${presetData.catapultAppFolder}/bin/catapult.tools.votingkey`,
+            `--secret=${votingPrivateKey}`,
+            `--startEpoch=${votingKeyStartEpoch}`,
+            `--endEpoch=${votingKeyEndEpoch}`,
+            `--output=/votingKeys/${privateKeyTreeFileName}`,
+        ];
+        const userId = await BootstrapUtils.resolveDockerUserFromParam(this.logger, this.user);
+        const { stdout, stderr } = await BootstrapUtils.runImageUsingExec(this.logger, {
+            catapultAppFolder: presetData.catapultAppFolder,
+            image: symbolServerImage,
+            userId: userId,
+            cmds: cmd,
+            binds: binds,
+        });
+
+        if (stdout.indexOf('<error> ') > -1) {
+            this.logger.info(stdout);
+            this.logger.error(stderr);
+            throw new Error('Voting key failed. Check the logs!');
+        }
+        return {
+            publicKey: votingAccount.publicKey,
+            startEpoch: votingKeyStartEpoch,
+            endEpoch: votingKeyEndEpoch,
+            filename: privateKeyTreeFileName,
+        };
+    }
+}

--- a/src/service/VotingService.ts
+++ b/src/service/VotingService.ts
@@ -84,7 +84,7 @@ export class VotingService {
             (presetData.useExperimentalNativeVotingKeyGeneration
                 ? new NativeVotingKeyFileProvider(logger)
                 : new CatapultVotingKeyFileProvider(logger, this.params.user));
-        const votingKeyFile = await provider.createVotingFile({
+        const { publicKey } = await provider.createVotingFile({
             presetData: presetData,
             nodeAccount: nodeAccount,
             nodePreset: nodePreset,
@@ -107,7 +107,7 @@ export class VotingService {
             logger.warn(`A new Voting File for the node ${nodeAccount.name} has been generated! `);
 
             logger.warn(
-                `Remember to send a Voting Key Link transaction from main ${nodeAccount.main.address} using the Voting Public Key: ${votingKeyFile.publicKey} with startEpoch: ${votingKeyStartEpoch} and endEpoch: ${votingKeyEndEpoch}`,
+                `Remember to send a Voting Key Link transaction from main ${nodeAccount.main.address} using the Voting Public Key: ${publicKey} with startEpoch: ${votingKeyStartEpoch} and endEpoch: ${votingKeyEndEpoch}`,
             );
             logger.warn(`For linking, you can use 'symbol-bootstrap link' command, the symbol cli, or the symbol desktop wallet.`);
             logger.warn('');

--- a/src/service/VotingService.ts
+++ b/src/service/VotingService.ts
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 
-import { writeFileSync } from 'fs';
 import { join } from 'path';
-import { Account } from 'symbol-sdk';
 import { Logger } from '../logger/Logger';
 import { ConfigPreset, NodeAccount, NodePreset } from '../model';
 import { BootstrapUtils } from './BootstrapUtils';
+import { CatapultVotingKeyFileProvider, NativeVotingKeyFileProvider, VotingKeyFileProvider } from './VotingKeyFileProvider';
 import { VotingUtils } from './VotingUtils';
 
-type VotingParams = { target: string; user: string };
+export interface VotingParams {
+    target: string;
+    user: string;
+    votingKeyFileProvider?: VotingKeyFileProvider;
+}
 
 export class VotingService {
     constructor(private readonly logger: Logger, protected readonly params: VotingParams) {}
@@ -35,7 +38,6 @@ export class VotingService {
         updateVotingKey: boolean | undefined,
         nemesisBlock: boolean,
     ): Promise<boolean> {
-        const symbolServerImage = presetData.symbolServerImage;
         const networkEpoch = currentNetworkEpoch || presetData.lastKnownNetworkEpoch || 1;
         const update = updateVotingKey === undefined ? presetData.autoUpdateVotingKeys : updateVotingKey;
         const logger = this.logger;
@@ -54,7 +56,7 @@ export class VotingService {
         }
         await BootstrapUtils.mkdir(votingKeysFolder);
         const votingUtils = new VotingUtils();
-        await BootstrapUtils.deleteFile(join(votingKeysFolder, 'metadata.yml'));
+        BootstrapUtils.deleteFile(join(votingKeysFolder, 'metadata.yml'));
         const currentVotingFiles = votingUtils.loadVotingFiles(votingKeysFolder);
         const maxVotingKeyEndEpoch = Math.max(currentVotingFiles[currentVotingFiles.length - 1]?.endEpoch || 0, networkEpoch - 1);
 
@@ -74,42 +76,26 @@ export class VotingService {
         }
         const votingKeyStartEpoch = maxVotingKeyEndEpoch + 1;
         const votingKeyEndEpoch = maxVotingKeyEndEpoch + votingKeyDesiredLifetime;
-        const votingAccount = Account.generateNewAccount(presetData.networkType);
-        const votingPrivateKey = votingAccount.privateKey;
         const epochs = votingKeyEndEpoch - votingKeyStartEpoch + 1;
         logger.info(`Creating Voting key file of ${epochs} epochs for node ${nodeAccount.name}. This could take a while!`);
         const privateKeyTreeFileName = `private_key_tree${currentVotingFiles.length + 1}.dat`;
-        if (presetData.useExperimentalNativeVotingKeyGeneration) {
-            logger.info('Voting file is created using the native typescript voting key file generator!');
-            const votingFile = await votingUtils.createVotingFile(votingPrivateKey, votingKeyStartEpoch, votingKeyEndEpoch);
-            writeFileSync(join(votingKeysFolder, privateKeyTreeFileName), votingFile);
-        } else {
-            logger.info(`Voting file is created using docker and the default's catapult.tools.votingkey`);
-            const binds = [`${votingKeysFolder}:/votingKeys:rw`];
-            const cmd = [
-                `${presetData.catapultAppFolder}/bin/catapult.tools.votingkey`,
-                `--secret=${votingPrivateKey}`,
-                `--startEpoch=${votingKeyStartEpoch}`,
-                `--endEpoch=${votingKeyEndEpoch}`,
-                `--output=/votingKeys/${privateKeyTreeFileName}`,
-            ];
-            const userId = await BootstrapUtils.resolveDockerUserFromParam(logger, this.params.user);
-            const { stdout, stderr } = await BootstrapUtils.runImageUsingExec(logger, {
-                catapultAppFolder: presetData.catapultAppFolder,
-                image: symbolServerImage,
-                userId: userId,
-                cmds: cmd,
-                binds: binds,
-            });
+        const provider =
+            this.params.votingKeyFileProvider ||
+            (presetData.useExperimentalNativeVotingKeyGeneration
+                ? new NativeVotingKeyFileProvider(logger)
+                : new CatapultVotingKeyFileProvider(logger, this.params.user));
+        const votingKeyFile = await provider.createVotingFile({
+            presetData: presetData,
+            nodeAccount: nodeAccount,
+            nodePreset: nodePreset,
+            votingKeysFolder: votingKeysFolder,
+            privateKeyTreeFileName: privateKeyTreeFileName,
+            votingKeyStartEpoch: votingKeyStartEpoch,
+            votingKeyEndEpoch: votingKeyEndEpoch,
+        });
 
-            if (stdout.indexOf('<error> ') > -1) {
-                logger.info(stdout);
-                logger.error(stderr);
-                throw new Error('Voting key failed. Check the logs!');
-            }
-        }
         if (nemesisBlock) {
-            // For a new local network, voting keys are in the nemesisBlock.
+            // For a new network, voting keys are in the nemesisBlock.
             logger.info('');
             logger.info(
                 `A new Voting File for the node ${nodeAccount.name} has been generated. The link transaction will be included in the nemesis block.`,
@@ -121,7 +107,7 @@ export class VotingService {
             logger.warn(`A new Voting File for the node ${nodeAccount.name} has been generated! `);
 
             logger.warn(
-                `Remember to send a Voting Key Link transaction from main ${nodeAccount.main.address} using the Voting Public Key: ${votingAccount.publicKey} with startEpoch: ${votingKeyStartEpoch} and endEpoch: ${votingKeyEndEpoch}`,
+                `Remember to send a Voting Key Link transaction from main ${nodeAccount.main.address} using the Voting Public Key: ${votingKeyFile.publicKey} with startEpoch: ${votingKeyStartEpoch} and endEpoch: ${votingKeyEndEpoch}`,
             );
             logger.warn(`For linking, you can use 'symbol-bootstrap link' command, the symbol cli, or the symbol desktop wallet.`);
             logger.warn('');

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -18,6 +18,7 @@ export * from './ReportService';
 export * from './RunService';
 export * from './TransactionUtils';
 export * from './VerifyService';
+export * from './VotingKeyFileProvider';
 export * from './VotingService';
 export * from './VotingUtils';
 export * from './ZipUtils';


### PR DESCRIPTION
This improvement allows devs to use another mechanism for voting key file creating. I would be using this in 2 ways:

1) I have a suite of tests to be pushed that does deep-dir comparison of different setups. The unit test needs a way to generate static files so we can do the assertions on all the files.  

The incoming test and unit test file provider:
https://github.com/symbol/symbol-bootstrap/blob/networkPresetFile/test/service/BootstrapService.test.ts
https://github.com/symbol/symbol-bootstrap/blob/networkPresetFile/test/service/BootstrapService.test.ts#L55

I need other PRs before pushing those unit tests.

2) Symbol services pre-create the voting files when generating the nemesis block on new networks, so they can then be used when creating each node. Those files are stored in the symbol-network's key-store.yml. 