### PR TITLE
Fix: Make sleep method respect Ctrl+C (SIGINT) interruptions

### DIFF
--- a/src/service/AsyncUtils.ts
+++ b/src/service/AsyncUtils.ts
@@ -29,13 +29,25 @@ export class AsyncUtils {
     })();
 
     public static sleep(ms: number): Promise<any> {
-        // Create a promise that rejects in <ms> milliseconds
+        // Check if stopProcess is already true before entering the sleep cycle
+        if (AsyncUtils.stopProcess) {
+            return Promise.resolve();
+        }
+
+        // Instead of a single setTimeout, use small intervals to check for stopProcess
         return new Promise<void>((resolve) => {
-            setTimeout(() => {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                //@ts-ignore
-                resolve();
-            }, ms);
+            const interval = 100; // Check every 100ms
+            let elapsed = 0;
+
+            const checkInterval = setInterval(() => {
+                elapsed += interval;
+
+                // If stopProcess flag is set or we've waited long enough, resolve
+                if (AsyncUtils.stopProcess || elapsed >= ms) {
+                    clearInterval(checkInterval);
+                    resolve();
+                }
+            }, interval);
         });
     }
 


### PR DESCRIPTION
## What this does

Fixes an issue where pressing Ctrl+C during the 10-second wait interval in `--healthCheck` would not immediately exit the process.

## Why it's needed

Improves CLI UX and makes the tool more responsive to user interruptions.

