### PR TITLE
fix: Add fallback decryption for crypto-js version compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "@oclif/plugin-help": "^5.1.11",
                 "archiver": "^5.3.0",
                 "cross-fetch": "^3.1.5",
+                "crypto-js": "^4.2.0",
                 "figlet": "^1.5.2",
                 "handlebars": "^4.7.7",
                 "inquirer": "^8.2.0",
@@ -2829,9 +2830,10 @@
             }
         },
         "node_modules/crypto-js": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-            "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+            "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+            "license": "MIT"
         },
         "node_modules/dashdash": {
             "version": "1.14.1",
@@ -10366,9 +10368,9 @@
             }
         },
         "crypto-js": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-            "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+            "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
         },
         "dashdash": {
             "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "@oclif/plugin-help": "^5.1.11",
         "archiver": "^5.3.0",
         "cross-fetch": "^3.1.5",
+        "crypto-js": "^4.2.0",
         "figlet": "^1.5.2",
         "handlebars": "^4.7.7",
         "inquirer": "^8.2.0",

--- a/src/service/ConfigLoader.ts
+++ b/src/service/ConfigLoader.ts
@@ -7,7 +7,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software1
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/src/service/ConfigLoader.ts
+++ b/src/service/ConfigLoader.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { copyFileSync, existsSync } from 'fs';
+import { existsSync, promises as fs } from 'fs';
 import * as _ from 'lodash';
 import { join } from 'path';
 import { Account, PublicAccount } from 'symbol-sdk';
@@ -306,15 +306,11 @@ export class ConfigLoader {
                 this.logger.warn(`Legacy encryption detected in ${generatedAddressLocation}. Upgrading to stronger encryption...`);
                 this.logger.info(`Creating backup of original file at ${backupLocation}`);
 
-                try {
-                    copyFileSync(generatedAddressLocation, backupLocation);
-                    this.logger.info(`Backup created successfully`);
-                } catch (e) {
-                    this.logger.error(`Failed to create backup for ${generatedAddressLocation}: ${e instanceof Error ? e.message : e}`);
-                }
-
-                // Proceed to upgrade the encryption in the background
-                YamlUtils.writeYaml(generatedAddressLocation, addresses, password)
+                fs.copyFile(generatedAddressLocation, backupLocation)
+                    .then(() => {
+                        this.logger.info(`Backup created successfully`);
+                        return YamlUtils.writeYaml(generatedAddressLocation, addresses, password);
+                    })
                     .then(() => {
                         this.logger.info(`Successfully upgraded encryption for ${generatedAddressLocation}`);
                         this.logger.info(`Original file backed up to ${backupLocation} (encrypted with legacy method)`);

--- a/src/service/ConfigLoader.ts
+++ b/src/service/ConfigLoader.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { existsSync, promises as fs } from 'fs';
+import { copyFileSync, existsSync } from 'fs';
 import * as _ from 'lodash';
 import { join } from 'path';
 import { Account, PublicAccount } from 'symbol-sdk';
@@ -306,11 +306,15 @@ export class ConfigLoader {
                 this.logger.warn(`Legacy encryption detected in ${generatedAddressLocation}. Upgrading to stronger encryption...`);
                 this.logger.info(`Creating backup of original file at ${backupLocation}`);
 
-                fs.copyFile(generatedAddressLocation, backupLocation)
-                    .then(() => {
-                        this.logger.info(`Backup created successfully`);
-                        return YamlUtils.writeYaml(generatedAddressLocation, addresses, password);
-                    })
+                try {
+                    copyFileSync(generatedAddressLocation, backupLocation);
+                    this.logger.info(`Backup created successfully`);
+                } catch (e) {
+                    this.logger.error(`Failed to create backup for ${generatedAddressLocation}: ${e instanceof Error ? e.message : e}`);
+                }
+
+                // Proceed to upgrade the encryption in the background
+                YamlUtils.writeYaml(generatedAddressLocation, addresses, password)
                     .then(() => {
                         this.logger.info(`Successfully upgraded encryption for ${generatedAddressLocation}`);
                         this.logger.info(`Original file backed up to ${backupLocation} (encrypted with legacy method)`);

--- a/src/service/ConfigLoader.ts
+++ b/src/service/ConfigLoader.ts
@@ -7,13 +7,13 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software1
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { existsSync } from 'fs';
+import { existsSync, promises as fs } from 'fs';
 import * as _ from 'lodash';
 import { join } from 'path';
 import { Account, PublicAccount } from 'symbol-sdk';
@@ -297,7 +297,30 @@ export class ConfigLoader {
     public loadExistingAddressesIfPreset(target: string, password: Password): Addresses | undefined {
         const generatedAddressLocation = this.getGeneratedAddressLocation(target);
         if (existsSync(generatedAddressLocation)) {
-            return new MigrationService(this.logger).migrateAddresses(YamlUtils.loadYaml(generatedAddressLocation, password));
+            const result = YamlUtils.loadYamlWithUpgradeInfo(generatedAddressLocation, password);
+            const addresses = new MigrationService(this.logger).migrateAddresses(result.data);
+
+            // If legacy encryption was upgraded, re-save the file with stronger encryption
+            if (result.hasLegacyUpgrade && password) {
+                const backupLocation = `${generatedAddressLocation}.bk`;
+                this.logger.warn(`Legacy encryption detected in ${generatedAddressLocation}. Upgrading to stronger encryption...`);
+                this.logger.info(`Creating backup of original file at ${backupLocation}`);
+
+                fs.copyFile(generatedAddressLocation, backupLocation)
+                    .then(() => {
+                        this.logger.info(`Backup created successfully`);
+                        return YamlUtils.writeYaml(generatedAddressLocation, addresses, password);
+                    })
+                    .then(() => {
+                        this.logger.info(`Successfully upgraded encryption for ${generatedAddressLocation}`);
+                        this.logger.info(`Original file backed up to ${backupLocation} (encrypted with legacy method)`);
+                    })
+                    .catch((e) => {
+                        this.logger.error(`Failed to upgrade encryption for ${generatedAddressLocation}: ${e.message}`);
+                    });
+            }
+
+            return addresses;
         }
         return undefined;
     }

--- a/src/service/ConfigLoader.ts
+++ b/src/service/ConfigLoader.ts
@@ -7,7 +7,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software1
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/src/service/CryptoUtils.ts
+++ b/src/service/CryptoUtils.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { createDecipheriv, pbkdf2Sync } from 'crypto';
 import * as _ from 'lodash';
 import { Crypto } from 'symbol-sdk';
 import { PrivateKeySecurityMode } from '../model';
@@ -108,12 +109,22 @@ export class CryptoUtils {
             return _.mapValues(value, (value: any, name: string) => CryptoUtils.decrypt(value, password, name));
         }
         if (this.isEncryptableKeyField(value, fieldName) && value.startsWith(CryptoUtils.ENCRYPT_PREFIX)) {
-            let decryptedValue;
+            const encryptedValue = value.substring(CryptoUtils.ENCRYPT_PREFIX.length);
+            // 1) Try current symbol-sdk decryption first (crypto-js >= 4.2.0 compatible)
+            let decryptedValue: string | undefined;
             try {
-                const encryptedValue = value.substring(CryptoUtils.ENCRYPT_PREFIX.length);
                 decryptedValue = Crypto.decrypt(encryptedValue, password);
             } catch (e) {
-                throw Error('Value could not be decrypted!');
+                decryptedValue = undefined;
+            }
+            // 2) Fallback to legacy decryption (crypto-js 4.1.1 equivalent: PBKDF2-SHA1 + AES-256-CBC)
+            if (!decryptedValue) {
+                try {
+                    decryptedValue = CryptoUtils.decryptLegacy(encryptedValue, password);
+                    CryptoUtils._legacyUpgradeDetected = true;
+                } catch (e) {
+                    throw Error('Value could not be decrypted!');
+                }
             }
             if (!decryptedValue) {
                 throw Error('Value could not be decrypted!');
@@ -122,6 +133,19 @@ export class CryptoUtils {
         }
         return value;
     }
+
+    /**
+     * Decrypts data and returns both the decrypted result and information about whether legacy encryption was upgraded.
+     * This method provides visibility into whether the data should be re-saved with stronger encryption.
+     */
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    public static decryptWithUpgradeInfo(value: any, password: string, fieldName?: string): { data: any; hasLegacyUpgrade: boolean } {
+        CryptoUtils._legacyUpgradeDetected = false;
+        const data = this.decrypt(value, password, fieldName);
+        return { data, hasLegacyUpgrade: CryptoUtils._legacyUpgradeDetected };
+    }
+
+    private static _legacyUpgradeDetected = false;
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     public static encryptedCount(value: any, fieldName?: string): number {
@@ -147,5 +171,27 @@ export class CryptoUtils {
             fieldName &&
             CryptoUtils.ENCRYPTABLE_KEYS.some((key) => fieldName.toLowerCase().endsWith(key.toLowerCase()))
         );
+    }
+
+    /**
+     * Legacy decryption logic equivalent to crypto-js 4.1.1 (PBKDF2-SHA1, iterations=1024, keySize=32, AES-256-CBC, PKCS7)
+     * Input format: `salt(16 bytes hex)` + `iv(16 bytes hex)` + `ciphertext(base64)`
+     */
+    private static decryptLegacy(data: string, password: string): string {
+        if (!data || data.length < 64) {
+            throw new Error('Invalid encrypted payload');
+        }
+        const saltHex = data.substring(0, 32);
+        const ivHex = data.substring(32, 64);
+        const ciphertextBase64 = data.substring(64);
+
+        const salt = Buffer.from(saltHex, 'hex');
+        const iv = Buffer.from(ivHex, 'hex');
+        const key = pbkdf2Sync(Buffer.from(password, 'utf8'), salt, 1024, 32, 'sha1');
+
+        const decipher = createDecipheriv('aes-256-cbc', key, iv);
+        let decrypted = decipher.update(ciphertextBase64, 'base64', 'utf8');
+        decrypted += decipher.final('utf8');
+        return decrypted;
     }
 }

--- a/src/service/CryptoUtils.ts
+++ b/src/service/CryptoUtils.ts
@@ -110,31 +110,20 @@ export class CryptoUtils {
         }
         if (this.isEncryptableKeyField(value, fieldName) && value.startsWith(CryptoUtils.ENCRYPT_PREFIX)) {
             const encryptedValue = value.substring(CryptoUtils.ENCRYPT_PREFIX.length);
+            // 1) Try current symbol-sdk decryption first (crypto-js >= 4.2.0 compatible)
             let decryptedValue: string | undefined;
-            // 1) If it looks like legacy payload, prefer legacy decryption first to positively detect upgrade scenario
-            if (CryptoUtils.isLegacyFormat(encryptedValue)) {
-                try {
-                    decryptedValue = CryptoUtils.decryptLegacy(encryptedValue, password);
-                    CryptoUtils._legacyUpgradeDetected = true;
-                } catch (e) {
-                    decryptedValue = undefined;
-                }
+            try {
+                decryptedValue = Crypto.decrypt(encryptedValue, password);
+            } catch (e) {
+                decryptedValue = undefined;
             }
-            // 2) If not legacy or legacy failed, try current symbol-sdk decryption (crypto-js >= 4.2.0 compatible)
+            // 2) Fallback to legacy decryption (crypto-js 4.1.1 equivalent: PBKDF2-SHA1 + AES-256-CBC)
             if (!decryptedValue) {
                 try {
-                    decryptedValue = Crypto.decrypt(encryptedValue, password);
-                } catch (e) {
-                    decryptedValue = undefined;
-                }
-            }
-            // 3) As a last resort, try legacy again if not already tried
-            if (!decryptedValue && !CryptoUtils._legacyUpgradeDetected) {
-                try {
                     decryptedValue = CryptoUtils.decryptLegacy(encryptedValue, password);
                     CryptoUtils._legacyUpgradeDetected = true;
                 } catch (e) {
-                    // ignore
+                    throw Error('Value could not be decrypted!');
                 }
             }
             if (!decryptedValue) {
@@ -204,24 +193,5 @@ export class CryptoUtils {
         let decrypted = decipher.update(ciphertextBase64, 'base64', 'utf8');
         decrypted += decipher.final('utf8');
         return decrypted;
-    }
-
-    /**
-     * Detects legacy encrypted payload format: 32 hex chars (salt) + 32 hex chars (iv) + base64 ciphertext
-     */
-    private static isLegacyFormat(data: string): boolean {
-        if (!data || data.length < 65) {
-            return false;
-        }
-        const saltHex = data.substring(0, 32);
-        const ivHex = data.substring(32, 64);
-        const ciphertextBase64 = data.substring(64);
-        const hexRegex = /^[0-9a-fA-F]+$/;
-        const b64Regex = /^[A-Za-z0-9+/=]+$/;
-        if (!hexRegex.test(saltHex) || !hexRegex.test(ivHex) || !b64Regex.test(ciphertextBase64)) {
-            return false;
-        }
-        // Additional lightweight validation: base64 length should be multiple of 4
-        return ciphertextBase64.length % 4 === 0;
     }
 }

--- a/src/service/CryptoUtils.ts
+++ b/src/service/CryptoUtils.ts
@@ -110,20 +110,31 @@ export class CryptoUtils {
         }
         if (this.isEncryptableKeyField(value, fieldName) && value.startsWith(CryptoUtils.ENCRYPT_PREFIX)) {
             const encryptedValue = value.substring(CryptoUtils.ENCRYPT_PREFIX.length);
-            // 1) Try current symbol-sdk decryption first (crypto-js >= 4.2.0 compatible)
             let decryptedValue: string | undefined;
-            try {
-                decryptedValue = Crypto.decrypt(encryptedValue, password);
-            } catch (e) {
-                decryptedValue = undefined;
-            }
-            // 2) Fallback to legacy decryption (crypto-js 4.1.1 equivalent: PBKDF2-SHA1 + AES-256-CBC)
-            if (!decryptedValue) {
+            // 1) If it looks like legacy payload, prefer legacy decryption first to positively detect upgrade scenario
+            if (CryptoUtils.isLegacyFormat(encryptedValue)) {
                 try {
                     decryptedValue = CryptoUtils.decryptLegacy(encryptedValue, password);
                     CryptoUtils._legacyUpgradeDetected = true;
                 } catch (e) {
-                    throw Error('Value could not be decrypted!');
+                    decryptedValue = undefined;
+                }
+            }
+            // 2) If not legacy or legacy failed, try current symbol-sdk decryption (crypto-js >= 4.2.0 compatible)
+            if (!decryptedValue) {
+                try {
+                    decryptedValue = Crypto.decrypt(encryptedValue, password);
+                } catch (e) {
+                    decryptedValue = undefined;
+                }
+            }
+            // 3) As a last resort, try legacy again if not already tried
+            if (!decryptedValue && !CryptoUtils._legacyUpgradeDetected) {
+                try {
+                    decryptedValue = CryptoUtils.decryptLegacy(encryptedValue, password);
+                    CryptoUtils._legacyUpgradeDetected = true;
+                } catch (e) {
+                    // ignore
                 }
             }
             if (!decryptedValue) {
@@ -193,5 +204,24 @@ export class CryptoUtils {
         let decrypted = decipher.update(ciphertextBase64, 'base64', 'utf8');
         decrypted += decipher.final('utf8');
         return decrypted;
+    }
+
+    /**
+     * Detects legacy encrypted payload format: 32 hex chars (salt) + 32 hex chars (iv) + base64 ciphertext
+     */
+    private static isLegacyFormat(data: string): boolean {
+        if (!data || data.length < 65) {
+            return false;
+        }
+        const saltHex = data.substring(0, 32);
+        const ivHex = data.substring(32, 64);
+        const ciphertextBase64 = data.substring(64);
+        const hexRegex = /^[0-9a-fA-F]+$/;
+        const b64Regex = /^[A-Za-z0-9+/=]+$/;
+        if (!hexRegex.test(saltHex) || !hexRegex.test(ivHex) || !b64Regex.test(ciphertextBase64)) {
+            return false;
+        }
+        // Additional lightweight validation: base64 length should be multiple of 4
+        return ciphertextBase64.length % 4 === 0;
     }
 }

--- a/src/service/YamlUtils.ts
+++ b/src/service/YamlUtils.ts
@@ -32,7 +32,14 @@ export class YamlUtils {
     }
 
     public static async writeYaml(path: string, object: unknown, password: Password): Promise<void> {
-        const yamlString = this.toYaml(password ? CryptoUtils.encrypt(object, Utils.validatePassword(password)) : object);
+        // Add a lightweight, non-encrypted metadata flag to indicate current encryption version
+        let objectToWrite: any = object;
+        if (password) {
+            const validated = Utils.validatePassword(password);
+            objectToWrite = { ...(object as any), __encryptionVersion: '2' };
+            objectToWrite = CryptoUtils.encrypt(objectToWrite, validated);
+        }
+        const yamlString = this.toYaml(objectToWrite);
         await this.writeTextFile(path, yamlString);
     }
 
@@ -83,13 +90,16 @@ export class YamlUtils {
         password: Password,
     ): { data: any; hasLegacyUpgrade: boolean; filePath: string } {
         const object = this.fromYaml(this.loadFileAsText(fileLocation));
+        const hasVersionMeta = !!(object && (object as any).__encryptionVersion === '2');
         if (password) {
             Utils.validatePassword(password);
             try {
                 const result = CryptoUtils.decryptWithUpgradeInfo(object, password);
+                // If metadata is present indicating current encryption, do not treat as legacy even if both decrypt paths succeed
+                const hasLegacyUpgrade = hasVersionMeta ? false : result.hasLegacyUpgrade || CryptoUtils.encryptedCount(object) > 0;
                 return {
                     data: result.data,
-                    hasLegacyUpgrade: result.hasLegacyUpgrade,
+                    hasLegacyUpgrade,
                     filePath: fileLocation,
                 };
             } catch (e) {

--- a/src/service/YamlUtils.ts
+++ b/src/service/YamlUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { promises as fsPromises, readFileSync } from 'fs';
+import { copyFileSync, promises as fsPromises, readFileSync } from 'fs';
 import * as yaml from 'js-yaml';
 import { dirname } from 'path';
 import { CryptoUtils } from './CryptoUtils';
@@ -45,11 +45,53 @@ export class YamlUtils {
     }
 
     public static loadYaml(fileLocation: string, password: Password): any {
+        const result = this.loadYamlWithUpgradeInfo(fileLocation, password);
+
+        // If legacy encryption was upgraded, re-save the file with stronger encryption
+        if (result.hasLegacyUpgrade && password) {
+            const backupLocation = `${fileLocation}.bk`;
+            console.log(`Legacy encryption detected in ${fileLocation}. Upgrading to stronger encryption...`);
+            console.log(`Creating backup of original file at ${backupLocation}`);
+
+            try {
+                copyFileSync(fileLocation, backupLocation);
+                console.log(`Backup created successfully`);
+
+                // Re-encrypt and save the file with stronger encryption (this is async, but we'll handle it in background)
+                YamlUtils.writeYaml(fileLocation, result.data, password)
+                    .then(() => {
+                        console.log(`Successfully upgraded encryption for ${fileLocation}`);
+                        console.log(`Original file backed up to ${backupLocation} (encrypted with legacy method)`);
+                    })
+                    .catch((e) => {
+                        console.error(`Failed to upgrade encryption for ${fileLocation}: ${e.message}`);
+                    });
+            } catch (e) {
+                console.error(`Failed to create backup for ${fileLocation}: ${e instanceof Error ? e.message : e}`);
+            }
+        }
+
+        return result.data;
+    }
+
+    /**
+     * Loads YAML file and returns both the data and information about whether legacy encryption was upgraded.
+     * This method provides visibility into whether the file should be re-saved with stronger encryption.
+     */
+    public static loadYamlWithUpgradeInfo(
+        fileLocation: string,
+        password: Password,
+    ): { data: any; hasLegacyUpgrade: boolean; filePath: string } {
         const object = this.fromYaml(this.loadFileAsText(fileLocation));
         if (password) {
             Utils.validatePassword(password);
             try {
-                return CryptoUtils.decrypt(object, password);
+                const result = CryptoUtils.decryptWithUpgradeInfo(object, password);
+                return {
+                    data: result.data,
+                    hasLegacyUpgrade: result.hasLegacyUpgrade,
+                    filePath: fileLocation,
+                };
             } catch (e) {
                 throw new KnownError(`Cannot decrypt file ${fileLocation}. Have you used the right password?`);
             }
@@ -60,7 +102,7 @@ export class YamlUtils {
                 );
             }
         }
-        return object;
+        return { data: object, hasLegacyUpgrade: false, filePath: fileLocation };
     }
 
     public static async writeTextFile(path: string, text: string): Promise<void> {

--- a/src/service/YamlUtils.ts
+++ b/src/service/YamlUtils.ts
@@ -32,14 +32,7 @@ export class YamlUtils {
     }
 
     public static async writeYaml(path: string, object: unknown, password: Password): Promise<void> {
-        // Add a lightweight, non-encrypted metadata flag to indicate current encryption version
-        let objectToWrite: any = object;
-        if (password) {
-            const validated = Utils.validatePassword(password);
-            objectToWrite = { ...(object as any), __encryptionVersion: '2' };
-            objectToWrite = CryptoUtils.encrypt(objectToWrite, validated);
-        }
-        const yamlString = this.toYaml(objectToWrite);
+        const yamlString = this.toYaml(password ? CryptoUtils.encrypt(object, Utils.validatePassword(password)) : object);
         await this.writeTextFile(path, yamlString);
     }
 
@@ -90,16 +83,13 @@ export class YamlUtils {
         password: Password,
     ): { data: any; hasLegacyUpgrade: boolean; filePath: string } {
         const object = this.fromYaml(this.loadFileAsText(fileLocation));
-        const hasVersionMeta = !!(object && (object as any).__encryptionVersion === '2');
         if (password) {
             Utils.validatePassword(password);
             try {
                 const result = CryptoUtils.decryptWithUpgradeInfo(object, password);
-                // If metadata is present indicating current encryption, do not treat as legacy even if both decrypt paths succeed
-                const hasLegacyUpgrade = hasVersionMeta ? false : result.hasLegacyUpgrade || CryptoUtils.encryptedCount(object) > 0;
                 return {
                     data: result.data,
-                    hasLegacyUpgrade,
+                    hasLegacyUpgrade: result.hasLegacyUpgrade,
                     filePath: fileLocation,
                 };
             } catch (e) {

--- a/test/service/ConfigLoader.test.ts
+++ b/test/service/ConfigLoader.test.ts
@@ -15,9 +15,13 @@
  */
 
 import { expect } from 'chai';
+import { createCipheriv, pbkdf2Sync, randomBytes } from 'crypto';
+import { existsSync } from 'fs';
 import 'mocha';
+import { join } from 'path';
+import { match, spy } from 'sinon';
 import { Assembly, Constants, LoggerFactory, LogType, Utils, YamlUtils } from '../../src';
-import { ConfigLoader, Preset } from '../../src/service';
+import { ConfigLoader, FileSystemService, Preset } from '../../src/service';
 
 const logger = LoggerFactory.getLogger(LogType.Silent);
 
@@ -557,5 +561,157 @@ describe('ConfigLoader', () => {
 
         expect(configLoader.applyValueTemplate({}, value)).to.be.deep.eq(value);
         expect(configLoader.applyValueTemplate({}, YamlUtils.fromYaml(YamlUtils.toYaml(value)))).to.be.deep.eq(value);
+    });
+
+    describe('loadExistingAddressesIfPreset legacy encryption upgrade', () => {
+        const fileSystemService = new FileSystemService(logger);
+        const testTarget = 'target/test-config-loader-legacy-upgrade';
+        const testAddressesFile = join(testTarget, 'addresses.yml');
+
+        beforeEach(async () => {
+            // Clean up test directory
+            fileSystemService.deleteFolder(testTarget);
+            await fileSystemService.mkdir(testTarget);
+        });
+
+        afterEach(() => {
+            fileSystemService.deleteFolder(testTarget);
+        });
+
+        it('should create backup and upgrade when legacy encryption is detected', async () => {
+            const password = '1234';
+            const configLoader = new ConfigLoader(logger);
+
+            // Create test addresses data with legacy encrypted private keys
+            const addresses = {
+                version: 2,
+                networkType: 104,
+                nodes: [
+                    {
+                        name: 'node1',
+                        main: {
+                            privateKey: createLegacyEncryptedValue(
+                                '6A4E05F63EA94949D1043D59A704CBA1E1FA1F57BF99E41D5F5DCF89E549D4E8',
+                                password,
+                            ),
+                            publicKey: 'F71853563BEE2C580C9AFA0A1A84203D14868C19279ABAABF8ADE89AF9AA9B30',
+                            address: 'TAEAUXUZOFODY2ZQZGV5DUVQ2TN3HBSXKGBEH5Q',
+                        },
+                        transport: {
+                            privateKey: createLegacyEncryptedValue(
+                                'E07C107F25DE9CBBC301683F527EBE05A47572EE810DB91D5C4FA6A7E0B9D5BF',
+                                password,
+                            ),
+                            publicKey: '41470F3A43095F493319A2241C3059B5EA0ECC89318E6ED32381A4AAEC4D13D1',
+                            address: 'TCZARKJGP4RXWWTUZRRYW4X5Z7UQFUXQ5K2VIJQ',
+                        },
+                    },
+                ],
+            };
+
+            // Write the addresses file with legacy encryption
+            await YamlUtils.writeYaml(testAddressesFile, addresses, '');
+
+            // Mock logger methods to capture log output
+            const loggerWarnSpy = spy(logger, 'warn');
+            const loggerInfoSpy = spy(logger, 'info');
+            const loggerErrorSpy = spy(logger, 'error');
+
+            // Call the method under test
+            const result = configLoader.loadExistingAddressesIfPreset(testTarget, password);
+
+            // Should return the decrypted addresses
+            expect(result).to.not.be.undefined;
+            if (result && result.nodes && result.nodes.length > 0) {
+                expect(result.nodes[0].main.privateKey).to.eq('6A4E05F63EA94949D1043D59A704CBA1E1FA1F57BF99E41D5F5DCF89E549D4E8');
+                expect(result.nodes[0].transport.privateKey).to.eq('E07C107F25DE9CBBC301683F527EBE05A47572EE810DB91D5C4FA6A7E0B9D5BF');
+            }
+
+            // Wait for async operations to complete
+            await new Promise((resolve) => setTimeout(resolve, 100));
+
+            // Verify backup file was created
+            const backupFile = `${testAddressesFile}.bk`;
+            expect(existsSync(backupFile)).to.be.true;
+
+            // Verify logging occurred
+            expect(loggerWarnSpy.calledWith(match('Legacy encryption detected'))).to.be.true;
+            expect(loggerInfoSpy.calledWith(match('Creating backup of original file'))).to.be.true;
+
+            // Restore logger methods
+            loggerWarnSpy.restore();
+            loggerInfoSpy.restore();
+            loggerErrorSpy.restore();
+        });
+
+        it('should not create backup when current encryption is used', async () => {
+            const password = '1234';
+            const configLoader = new ConfigLoader(logger);
+
+            // Create test addresses data with current encryption
+            const plainAddresses = {
+                version: 2,
+                networkType: 104,
+                nodes: [
+                    {
+                        name: 'node1',
+                        main: {
+                            privateKey: '6A4E05F63EA94949D1043D59A704CBA1E1FA1F57BF99E41D5F5DCF89E549D4E8',
+                            publicKey: 'F71853563BEE2C580C9AFA0A1A84203D14868C19279ABAABF8ADE89AF9AA9B30',
+                            address: 'TAEAUXUZOFODY2ZQZGV5DUVQ2TN3HBSXKGBEH5Q',
+                        },
+                    },
+                ],
+            };
+
+            // Encrypt with current method and write the file
+            await YamlUtils.writeYaml(testAddressesFile, plainAddresses, password);
+
+            // Mock logger methods
+            const loggerWarnSpy = spy(logger, 'warn');
+
+            // Call the method under test
+            const result = configLoader.loadExistingAddressesIfPreset(testTarget, password);
+
+            // Should return the decrypted addresses
+            expect(result).to.not.be.undefined;
+            if (result && result.nodes && result.nodes.length > 0) {
+                expect(result.nodes[0].main.privateKey).to.eq('6A4E05F63EA94949D1043D59A704CBA1E1FA1F57BF99E41D5F5DCF89E549D4E8');
+            }
+
+            // Wait for async operations to complete
+            await new Promise((resolve) => setTimeout(resolve, 100));
+
+            // Verify backup file was NOT created
+            const backupFile = `${testAddressesFile}.bk`;
+            expect(existsSync(backupFile)).to.be.false;
+
+            // Verify no warning was logged
+            expect(loggerWarnSpy.calledWith(match('Legacy encryption detected'))).to.be.false;
+
+            // Restore logger methods
+            loggerWarnSpy.restore();
+        });
+
+        it('should return undefined when addresses file does not exist', () => {
+            const configLoader = new ConfigLoader(logger);
+            const result = configLoader.loadExistingAddressesIfPreset('nonexistent-target', '1234');
+            expect(result).to.be.undefined;
+        });
+
+        /**
+         * Helper function to create legacy encrypted value (equivalent to crypto-js 4.1.1)
+         */
+        function createLegacyEncryptedValue(plaintext: string, password: string): string {
+            const salt = randomBytes(16);
+            const iv = randomBytes(16);
+            const key = pbkdf2Sync(Buffer.from(password, 'utf8'), salt, 1024, 32, 'sha1');
+
+            const cipher = createCipheriv('aes-256-cbc', key, iv);
+            let ciphertext = cipher.update(plaintext, 'utf8', 'base64');
+            ciphertext += cipher.final('base64');
+
+            return 'ENCRYPTED:' + salt.toString('hex') + iv.toString('hex') + ciphertext;
+        }
     });
 });

--- a/test/service/CryptoUtils.test.ts
+++ b/test/service/CryptoUtils.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { expect } from 'chai';
+import { createCipheriv, pbkdf2Sync, randomBytes } from 'crypto';
 import 'mocha';
 import { Utils } from '../../src';
 import { PrivateKeySecurityMode } from '../../src/model';
@@ -128,6 +129,93 @@ describe('CryptoUtils', () => {
         } catch (e) {
             expect(Utils.getMessage(e)).eq('Value could not be decrypted!');
         }
+    });
+
+    it('decrypt legacy encrypted value (crypto-js 4.1.1 equivalent)', () => {
+        const password = '1234';
+        const plain = 'abc';
+
+        // Legacy format: salt(16 bytes hex) + iv(16 bytes hex) + ciphertext(base64)
+        const salt = randomBytes(16);
+        const iv = randomBytes(16);
+        const key = pbkdf2Sync(Buffer.from(password, 'utf8'), salt, 1024, 32, 'sha1');
+        const cipher = createCipheriv('aes-256-cbc', key, iv);
+        let ciphertext = cipher.update(plain, 'utf8', 'base64');
+        ciphertext += cipher.final('base64');
+        const payload = 'ENCRYPTED:' + salt.toString('hex') + iv.toString('hex') + ciphertext;
+
+        const obj = { anotherPrivateKey: payload } as any;
+        const decrypted = CryptoUtils.decrypt(obj, password);
+        expect(decrypted.anotherPrivateKey).eq(plain);
+    });
+
+    it('decrypt legacy encrypted value should fail with invalid password', () => {
+        const password = '1234';
+        const invalidPassword = '0000';
+        const plain = 'abc';
+
+        const salt = randomBytes(16);
+        const iv = randomBytes(16);
+        const key = pbkdf2Sync(Buffer.from(password, 'utf8'), salt, 1024, 32, 'sha1');
+        const cipher = createCipheriv('aes-256-cbc', key, iv);
+        let ciphertext = cipher.update(plain, 'utf8', 'base64');
+        ciphertext += cipher.final('base64');
+        const payload = 'ENCRYPTED:' + salt.toString('hex') + iv.toString('hex') + ciphertext;
+
+        const obj = { anotherPrivateKey: payload } as any;
+        try {
+            CryptoUtils.decrypt(obj, invalidPassword);
+            expect(1).eq(0);
+        } catch (e) {
+            expect(Utils.getMessage(e)).eq('Value could not be decrypted!');
+        }
+    });
+
+    it('decryptWithUpgradeInfo should detect legacy encryption upgrade', () => {
+        const password = '1234';
+        const plain = 'secretKey123';
+
+        // Create legacy encrypted data
+        const salt = randomBytes(16);
+        const iv = randomBytes(16);
+        const key = pbkdf2Sync(Buffer.from(password, 'utf8'), salt, 1024, 32, 'sha1');
+        const cipher = createCipheriv('aes-256-cbc', key, iv);
+        let ciphertext = cipher.update(plain, 'utf8', 'base64');
+        ciphertext += cipher.final('base64');
+        const legacyPayload = 'ENCRYPTED:' + salt.toString('hex') + iv.toString('hex') + ciphertext;
+
+        const originalObj = {
+            anotherPrivateKey: legacyPayload,
+            publicKey: 'notEncrypted',
+        };
+
+        // Decrypt with upgrade info
+        const result = CryptoUtils.decryptWithUpgradeInfo(originalObj, password);
+
+        // Should indicate legacy encryption was used
+        expect(result.hasLegacyUpgrade).to.be.true;
+
+        // Data should be properly decrypted
+        expect(result.data.anotherPrivateKey).eq(plain);
+        expect(result.data.publicKey).eq('notEncrypted');
+    });
+
+    it('decryptWithUpgradeInfo should not flag current encrypted data as upgraded', () => {
+        const password = '1234';
+        const plain = 'secretKey123';
+
+        // Create current encrypted data using current method
+        const currentObj = { anotherPrivateKey: plain };
+        const encryptedObj = CryptoUtils.encrypt(currentObj, password);
+
+        // Decrypt with upgrade info
+        const result = CryptoUtils.decryptWithUpgradeInfo(encryptedObj, password);
+
+        // Should indicate no legacy upgrade was needed
+        expect(result.hasLegacyUpgrade).to.be.false;
+
+        // Data should be properly decrypted
+        expect(result.data.anotherPrivateKey).eq(plain);
     });
 
     it('it removes private keys', () => {


### PR DESCRIPTION
- Add legacy decryption method for crypto-js 4.1.1 compatibility
- Implement automatic fallback when symbol-sdk decryption fails
- Add comprehensive test cases for both new and legacy encryption formats
- Ensure backward compatibility with existing encrypted data
- Automatically re-encrypt files if legacy encryption is detected

This resolves issues where encrypted data couldn't be decrypted due to crypto-js version mismatches between different symbol-sdk versions.