### PR TITLE
fix: set OPENSSL_CONF env variable in certificate script

### DIFF
--- a/src/service/CertificateService.ts
+++ b/src/service/CertificateService.ts
@@ -235,6 +235,8 @@ export class CertificateService {
     `;
         return `set -e
 
+export OPENSSL_CONF=/usr/lib/ssl/openssl.cnf
+
 # Clean up old versions files.
 rm -rf new_certs
 rm -f index.txt*


### PR DESCRIPTION
## Summary
This pull request updates the certificate creation script to explicitly set the `OPENSSL_CONF` environment variable.
This change will ensure that OpenSSL uses the correct configuration file when running in a Docker image and addresses the issue of environment variables not being set by default.

## Details
- Added `export OPENSSL_CONF=/usr/lib/ssl/openssl.cnf` to the certificate creation script.

## Motivation
The `OPENSSL_CONF` environment variable is not set in the 1.0.3.8 Docker image, which may cause errors during certificate creation.
Setting this variable in the script will ensure consistent behavior across different environments.

Please review and let me know if further changes are needed.