### PR TITLE
fix: add x509v3 extensions for CA and node certificates in configuration

### DIFF
--- a/config/cert/ca.cnf.mustache
+++ b/config/cert/ca.cnf.mustache
@@ -17,6 +17,17 @@ commonName              = supplied
 [req]
 prompt = no
 distinguished_name = dn
+x509_extensions = x509_v3_ca
 
 [dn]
 CN = {{{name}}}-account
+
+[x509_v3_ca]
+basicConstraints = critical,CA:TRUE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+
+[x509_v3_node]
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer

--- a/src/service/CertificateService.ts
+++ b/src/service/CertificateService.ts
@@ -230,7 +230,7 @@ export class CertificateService {
         const createCaCertificate = renew
             ? `openssl x509 -in ${CertificateService.CA_CERTIFICATE_FILE_NAME}  -text -noout`
             : `# create CA cert and self-sign it
-    openssl req -config ca.cnf -keyform PEM -key ca.key.pem -new -x509 -days ${caCertificateExpirationInDays} -out ${CertificateService.CA_CERTIFICATE_FILE_NAME}
+    openssl req -config ca.cnf -keyform PEM -key ca.key.pem -new -x509 -days ${caCertificateExpirationInDays} -out ${CertificateService.CA_CERTIFICATE_FILE_NAME} -extensions x509_v3_ca
     openssl x509 -in ${CertificateService.CA_CERTIFICATE_FILE_NAME}  -text -noout
     `;
         return `set -e
@@ -263,7 +263,7 @@ openssl req  -text -noout -verify -in node.csr.pem
 # CA side
 
 # sign cert for 375 days
-openssl ca -batch -config ca.cnf -days ${nodeCertificateExpirationInDays} -notext -in node.csr.pem -out ${CertificateService.NODE_CERTIFICATE_FILE_NAME}
+openssl ca -batch -config ca.cnf -days ${nodeCertificateExpirationInDays} -notext -in node.csr.pem -out ${CertificateService.NODE_CERTIFICATE_FILE_NAME} -extensions x509_v3_node
 openssl verify -CAfile ${CertificateService.CA_CERTIFICATE_FILE_NAME} ${CertificateService.NODE_CERTIFICATE_FILE_NAME}
 
 # finally create full crt

--- a/test/service/CertificateService.test.ts
+++ b/test/service/CertificateService.test.ts
@@ -16,6 +16,7 @@
 
 import { expect } from '@oclif/test';
 import { deepStrictEqual } from 'assert';
+import { execSync } from 'child_process';
 import { promises as fsPromises, readFileSync } from 'fs';
 import 'mocha';
 import { join } from 'path';
@@ -89,6 +90,11 @@ describe('CertificateService', () => {
             });
     }
 
+    async function verifyCertX509v3Extensions(certFileName: string) {
+        const opensslOut = execSync(`openssl x509 -in ${join(target, certFileName)} -text -noout`).toString();
+        expect(opensslOut.includes('X509v3 extensions')).eq(true);
+    }
+
     it('createCertificates', async () => {
         fileSystemService.deleteFolder(target);
 
@@ -105,6 +111,8 @@ describe('CertificateService', () => {
         };
         expect(expectedMetadata).deep.eq(YamlUtils.loadYaml(join(target, 'metadata.yml'), false));
         await verifyCertFolder();
+        await verifyCertX509v3Extensions('ca.cert.pem');
+        await verifyCertX509v3Extensions('node.crt.pem');
     });
 
     it('createCertificates expiration warnings', async () => {


### PR DESCRIPTION
## Summary
This pull request updates the certificate generation process to support x509 v3 certificates.
It introduces the logic required for v3 certificate creation and adjusts related test cases accordingly.

## Details
- Added logic for generating x509 v3 certificates
- Updated and added related test cases

I have added a test that checks for x509v3, but it uses the `openssl` command, so it depends on the execution environment and might be better not to have it...
Please review and let me know if further changes are needed.